### PR TITLE
Break the 'Updates' homepage section out into its own partial

### DIFF
--- a/wp-content/themes/largoproject/homepages/templates/largo.php
+++ b/wp-content/themes/largoproject/homepages/templates/largo.php
@@ -167,24 +167,9 @@
 			<a href="#" class="btn" id="btn-largo-1">See More</a>
 		</div>
 	</section>
-	<section id="project-updates" class="largo-section">
-		<h2>Latest Updates</h2>
-		<div class="max-width-container clearfix">
-			<div class="update-row">
-				<span class="update-date">12.05.16</span>
-				<a href="#">Quo tem elit ut alit porecto il id</a>
-			</div>
-			<div class="update-row">
-				<span class="update-date">11.15.16</span>
-				<a href="#">Us eum sin nulpa sinihil luptatur accuptas mo is vellabo rionectur samenih</a>
-			</div>
-			<div class="update-row">
-				<span class="update-date">10.24.16</span>
-				<a href="#">Imincip samusam re sinctorecab intur sum il</a>
-			</div>
-			<span id="see-more"><a href="https://nerds.inn.org/tag/project-largo/">Read More...</a></span>
-		</div>
-	</section>
+	<?php
+		// get_template_part( 'partials/home', 'updates' );
+	?>
 	<section id="largo-support" class="largo-section">
 		<div class="max-width-container">
 			<a href="#"><h2>Support</h2></a>

--- a/wp-content/themes/largoproject/partials/home-updates.php
+++ b/wp-content/themes/largoproject/partials/home-updates.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Switch to the Nerds site, grab most-recent 3 posts in the "project-largo" tag
+ */
+?>
+<section id="project-updates" class="largo-section">
+	<h2>Latest Updates</h2>
+	<div class="max-width-container clearfix">
+		<div class="update-row">
+			<span class="update-date">12.05.16</span>
+			<a href="#">Quo tem elit ut alit porecto il id</a>
+		</div>
+		<div class="update-row">
+			<span class="update-date">11.15.16</span>
+			<a href="#">Us eum sin nulpa sinihil luptatur accuptas mo is vellabo rionectur samenih</a>
+		</div>
+		<div class="update-row">
+			<span class="update-date">10.24.16</span>
+			<a href="#">Imincip samusam re sinctorecab intur sum il</a>
+		</div>
+		<span id="see-more"><a href="https://nerds.inn.org/tag/project-largo/">Read More...</a></span>
+	</div>
+</section>


### PR DESCRIPTION
## Changes

- Makes the "updates" portion of the homepage its own partial
- Comments out the get_template_part call until this partial is complete

Ticket to complete work on this partial: https://app.asana.com/0/0/255883930768493