### PR TITLE
Sticky nav and main nav clean-up in largoproject theme

### DIFF
--- a/wp-content/themes/largoproject/css/style.css
+++ b/wp-content/themes/largoproject/css/style.css
@@ -730,6 +730,98 @@ body.admin-bar .sticky-nav-holder {
 .sticky-nav-holder {
   border-bottom: none;
 }
+/**************
+ * random copied stuff pre-transition
+ */
+/* Navigation Bar */
+nav#main-nav {
+  background-color: #f48030;
+  padding: 0 2.5%;
+}
+nav#main-nav img {
+  max-width: 200px;
+  display: inline-block;
+  float: left;
+  margin: 20px 100px 20px 100px;
+}
+nav#main-nav div.navbar-inner {
+  float: none;
+}
+nav#main-nav ul {
+  margin: 20px;
+}
+nav#main-nav ul li {
+  display: inline-block;
+  margin-top: 16px;
+  margin-right: 30px;
+  font-size: 1.2em;
+}
+nav#main-nav ul li a {
+  color: white;
+  font-weight: 300;
+}
+nav#main-nav ul#navbar-left {
+  float: left;
+}
+nav#main-nav ul#navbar-right {
+  float: right;
+  margin: 0;
+}
+nav#main-nav a.btn-navbar:hover {
+  background-color: #f2690d;
+}
+nav#main-nav .btn-navbar {
+  display: none;
+  padding: 0 20px;
+  line-height: 69px;
+}
+nav#main-nav .btn-navbar .bars {
+  display: inline-block;
+}
+nav#main-nav .btn-navbar .bars .icon-bar {
+  background-color: white;
+  display: block;
+  width: 18px;
+  height: 3px;
+  margin-top: 3px;
+}
+@media (max-width: 1000px) {
+  nav#main-nav img {
+    margin: 2% 8% 2% 8%;
+    max-width: 150px;
+  }
+  nav#main-nav ul li {
+    font-size: 1em;
+    margin-right: 15px;
+    margin-left: 15px;
+  }
+  nav#main-nav ul {
+    margin: 12px;
+  }
+}
+@media (max-width: 769px) {
+  nav#main-nav img {
+    height: 44px;
+    margin: 6px 0 6px 0;
+  }
+  nav#main-nav ul {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+  nav#main-nav ul li {
+    margin-top: 0;
+    margin-bottom: 0;
+    line-height: 56px;
+  }
+}
+@media (max-width: 650px) {
+  nav#main-nav ul#navbar-left {
+    display: none;
+  }
+  nav#main-nav .btn-navbar {
+    display: block;
+  }
+}
 .site-hero {
   width: 100%;
   text-align: center;
@@ -778,58 +870,6 @@ body.admin-bar .sticky-nav-holder {
   display: inline;
 }
 /*** Largo-Re-Design ***/
-/* Navigation Bar */
-nav#largo-nav {
-  background-color: #f48030;
-  padding: 0 2.5%;
-}
-nav#largo-nav img {
-  max-width: 200px;
-  display: inline-block;
-  float: left;
-  margin: 20px 100px 20px 100px;
-}
-nav#largo-nav div.navbar-inner {
-  float: none;
-}
-nav#largo-nav ul {
-  margin: 20px;
-}
-nav#largo-nav ul li {
-  display: inline-block;
-  margin-top: 16px;
-  margin-right: 30px;
-  font-size: 1.2em;
-}
-nav#largo-nav ul li a {
-  color: white;
-  font-weight: 300;
-}
-nav#largo-nav ul#navbar-left {
-  float: left;
-}
-nav#largo-nav ul#navbar-right {
-  float: right;
-  margin: 0;
-}
-nav#largo-nav a.btn-navbar:hover {
-  background-color: #f2690d;
-}
-nav#largo-nav .btn-navbar {
-  display: none;
-  padding: 0 20px;
-  line-height: 69px;
-}
-nav#largo-nav .btn-navbar .bars {
-  display: inline-block;
-}
-nav#largo-nav .btn-navbar .bars .icon-bar {
-  background-color: white;
-  display: block;
-  width: 18px;
-  height: 3px;
-  margin-top: 3px;
-}
 /* Sections - Hide these parts */
 div.site-hero {
   display: none;
@@ -1098,18 +1138,6 @@ nav#largo-footer ul li a {
   }
 }
 @media (max-width: 1000px) {
-  nav#largo-nav img {
-    margin: 2% 8% 2% 8%;
-    max-width: 150px;
-  }
-  nav#largo-nav ul li {
-    font-size: 1em;
-    margin-right: 15px;
-    margin-left: 15px;
-  }
-  nav#largo-nav ul {
-    margin: 12px;
-  }
   div.max-width-container {
     margin: 0 20px;
   }
@@ -1188,28 +1216,7 @@ nav#largo-footer ul li a {
     width: 300px;
   }
 }
-@media (max-width: 769px) {
-  nav#largo-nav img {
-    height: 44px;
-    margin: 6px 0 6px 0;
-  }
-  nav#largo-nav ul {
-    margin-top: 0;
-    margin-bottom: 0;
-  }
-  nav#largo-nav ul li {
-    margin-top: 0;
-    margin-bottom: 0;
-    line-height: 56px;
-  }
-}
 @media (max-width: 650px) {
-  nav#largo-nav ul#navbar-left {
-    display: none;
-  }
-  nav#largo-nav .btn-navbar {
-    display: block;
-  }
   section#largo-hero div#hero-description {
     width: 100%;
     float: none;

--- a/wp-content/themes/largoproject/css/style.css
+++ b/wp-content/themes/largoproject/css/style.css
@@ -723,102 +723,125 @@ body.admin-bar .sticky-nav-holder {
     background-color: #fcd9c1;
   }
 }
-.navbar li.home-icon > a img {
-  max-height: auto;
-  height: 44px;
-}
 .sticky-nav-holder {
   border-bottom: none;
+}
+.navbar.sticky-navbar li > a:hover {
+  background-color: #e5650c;
+}
+.navbar.sticky-navbar li.home-icon > a img {
+  vertical-align: -25%;
+  height: 44px;
+}
+.navbar.sticky-navbar li.dropdown .dropdown-menu li a {
+  color: #484848;
 }
 /**************
  * random copied stuff pre-transition
  */
 /* Navigation Bar */
-nav#main-nav {
+#main-nav {
   background-color: #f48030;
   padding: 0 2.5%;
 }
-nav#main-nav img {
-  max-width: 200px;
+#main-nav img {
   display: inline-block;
   float: left;
-  margin: 20px 100px 20px 100px;
 }
-nav#main-nav div.navbar-inner {
+#main-nav div.navbar-inner {
   float: none;
 }
-nav#main-nav ul {
+#main-nav ul {
   margin: 20px;
 }
-nav#main-nav ul li {
+#main-nav ul li {
   display: inline-block;
-  margin-top: 16px;
   margin-right: 30px;
   font-size: 1.2em;
 }
-nav#main-nav ul li a {
+#main-nav ul li a {
   color: white;
   font-weight: 300;
 }
-nav#main-nav ul#navbar-left {
+#main-nav li > a:hover {
+  background-color: #f48030;
+  text-decoration: underline;
+}
+#main-nav ul#navbar-left {
   float: left;
 }
-nav#main-nav ul#navbar-right {
+#main-nav ul#navbar-right {
   float: right;
   margin: 0;
 }
-nav#main-nav a.btn-navbar:hover {
+#main-nav a.btn-navbar:hover {
   background-color: #f2690d;
 }
-nav#main-nav .btn-navbar {
+#main-nav .btn-navbar {
   display: none;
   padding: 0 20px;
   line-height: 69px;
 }
-nav#main-nav .btn-navbar .bars {
+#main-nav .btn-navbar .bars {
   display: inline-block;
 }
-nav#main-nav .btn-navbar .bars .icon-bar {
+#main-nav .btn-navbar .bars .icon-bar {
   background-color: white;
   display: block;
   width: 18px;
   height: 3px;
   margin-top: 3px;
 }
-@media (max-width: 1000px) {
-  nav#main-nav img {
-    margin: 2% 8% 2% 8%;
-    max-width: 150px;
+@media (min-width: 1001px) {
+  #main-nav img {
+    max-width: 200px;
+    margin: 20px 100px 20px 100px;
   }
-  nav#main-nav ul li {
+  #main-nav .nav {
+    float: right;
+  }
+  #main-nav .nav li a {
+    line-height: 58px;
+  }
+}
+@media (max-width: 1000px) {
+  #main-nav img {
+    max-width: 150px;
+    height: 40px;
+  }
+  #main-nav ul li {
     font-size: 1em;
     margin-right: 15px;
     margin-left: 15px;
   }
-  nav#main-nav ul {
+  #main-nav .home-icon,
+  #main-nav ul {
     margin: 12px;
   }
 }
 @media (max-width: 769px) {
-  nav#main-nav img {
+  #main-nav img {
     height: 44px;
     margin: 6px 0 6px 0;
   }
-  nav#main-nav ul {
+  #main-nav ul {
     margin-top: 0;
     margin-bottom: 0;
   }
-  nav#main-nav ul li {
+  #main-nav ul li {
     margin-top: 0;
     margin-bottom: 0;
     line-height: 56px;
   }
+  .navbar.sticky-navbar li.home-icon a img {
+    vertical-align: middle;
+  }
 }
 @media (max-width: 650px) {
-  nav#main-nav ul#navbar-left {
+  #main-nav ul#navbar-left {
     display: none;
   }
-  nav#main-nav .btn-navbar {
+  #main-nav .btn-navbar {
     display: block;
   }
 }

--- a/wp-content/themes/largoproject/css/style.css
+++ b/wp-content/themes/largoproject/css/style.css
@@ -404,6 +404,332 @@ body.normal.page #content.guide-page {
     margin-bottom: 8px;
   }
 }
+.clearfix {
+  *zoom: 1;
+}
+.clearfix:before,
+.clearfix:after {
+  display: table;
+  content: "";
+}
+.clearfix:after {
+  clear: both;
+}
+.visuallyhidden {
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+}
+.hide-text {
+  font: 0/0 a;
+  color: transparent;
+  text-shadow: none;
+  background-color: transparent;
+  border: 0;
+}
+.input-block-level {
+  display: block;
+  width: 100%;
+  min-height: 28px;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -ms-box-sizing: border-box;
+  box-sizing: border-box;
+}
+.sticky-nav-container {
+  margin: 0 auto;
+  position: relative;
+}
+.sticky-nav-holder {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 99998;
+  visibility: hidden;
+  opacity: 0;
+  background-color: #f48030;
+  border-bottom: 1px solid #dddddd;
+  -webkit-transition: opacity 0.3s;
+  -moz-transition: opacity 0.3s;
+  -ms-transition: opacity 0.3s;
+  -o-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+}
+.sticky-nav-holder.transitioning {
+  overflow: hidden;
+  height: 56px;
+}
+.sticky-nav-holder.transitioning .navbar {
+  opacity: 0;
+}
+.sticky-nav-holder.show {
+  visibility: visible;
+  opacity: 1;
+}
+body.admin-bar .sticky-nav-holder {
+  top: 32px;
+}
+@media (max-width: 782px) {
+  body.admin-bar .sticky-nav-holder {
+    top: 46px;
+  }
+}
+@media (max-width: 600px) {
+  body.admin-bar .sticky-nav-holder {
+    top: 0;
+  }
+}
+@media (min-width: 769px) {
+  .sticky-nav-holder {
+    display: none;
+  }
+  body .sticky-nav-holder.main_nav_hide_article,
+  body .sticky-nav-holder.sticky_nav_display {
+    display: block;
+  }
+}
+.navbar.sticky-navbar {
+  margin-bottom: 0;
+  -webkit-transition: opacity 0.3s;
+  -moz-transition: opacity 0.3s;
+  -ms-transition: opacity 0.3s;
+  -o-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+}
+.navbar.sticky-navbar .nav {
+  color: #ffffff;
+}
+.navbar.sticky-navbar li a {
+  line-height: 56px;
+  color: #ffffff;
+}
+.navbar.sticky-navbar li a:hover {
+  color: #ffffff;
+}
+.navbar.sticky-navbar li a .caret:before {
+  border-top-color: #ffffff;
+}
+.navbar.sticky-navbar li a:hover .caret:before {
+  border-top-color: #ffffff;
+}
+.navbar.sticky-navbar li.home-link > a:hover {
+  color: #ffffff;
+}
+.navbar.sticky-navbar li.dropdown .dropdown-menu li a {
+  color: #ffffff;
+}
+.navbar.sticky-navbar li.dropdown .dropdown-menu li a:hover {
+  color: #ffffff;
+}
+.navbar.sticky-navbar .social-icons {
+  margin: 0;
+  float: left;
+}
+.navbar.sticky-navbar .btn-navbar {
+  padding: 0 10px 0 10px;
+  margin-right: 0;
+  line-height: 56px;
+}
+.navbar.sticky-navbar .btn-navbar .bars {
+  display: inline-block;
+}
+.navbar.sticky-navbar .btn-navbar .icon-bar {
+  background-color: #ffffff;
+}
+.navbar.sticky-navbar .btn-navbar:hover .icon-bar {
+  background-color: #ffffff;
+}
+.navbar.sticky-navbar.home-link {
+  min-width: 40px;
+  text-align: center;
+}
+.navbar.sticky-navbar.home-link .nav > li a img {
+  width: 1.49em;
+  height: 1.49em;
+}
+.navbar.sticky-navbar.home-link .nav > li .icon-home:before {
+  position: relative;
+  top: 0;
+}
+.navbar.sticky-navbar .nav-right {
+  float: right;
+}
+.navbar.sticky-navbar .nav-right #header-extras {
+  float: left;
+  margin: 0;
+}
+.navbar.sticky-navbar .nav-right #header-extras a.donate-link:hover {
+  background: transparent;
+}
+.navbar.sticky-navbar .nav-right #header-extras .donate a span {
+  padding: 4px 8px;
+  color: #ffffff;
+  background-color: #df4646;
+}
+.navbar.sticky-navbar .nav-right #header-extras .donate a span:hover {
+  background-color: #e35c5c;
+}
+.navbar.sticky-navbar .nav-right #header-extras .donate a span i {
+  display: none;
+}
+.navbar.sticky-navbar .nav-right .form-search {
+  position: relative;
+}
+.navbar.sticky-navbar .nav-right .form-search .toggle {
+  color: #ffffff;
+  display: inline-block;
+  text-align: center;
+  cursor: pointer;
+  position: relative;
+  z-index: 91;
+  -webkit-transition: 0.3s;
+  -moz-transition: 0.3s;
+  -ms-transition: 0.3s;
+  -o-transition: 0.3s;
+  transition: 0.3s;
+}
+.navbar.sticky-navbar .nav-right .form-search .input-append {
+  position: absolute;
+  right: 44px;
+  top: 0;
+  right: 0;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: 0.3s;
+  -moz-transition: 0.3s;
+  -ms-transition: 0.3s;
+  -o-transition: 0.3s;
+  transition: 0.3s;
+  padding: 10px;
+  z-index: 90;
+  width: 246px;
+}
+.navbar.sticky-navbar .nav-right .form-search .input-append .text-input-wrapper {
+  display: block;
+  float: left;
+  width: 196px;
+}
+.navbar.sticky-navbar .nav-right .form-search .input-append input {
+  width: 100%;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -ms-box-sizing: border-box;
+  box-sizing: border-box;
+  height: 36px !important;
+}
+.navbar.sticky-navbar .nav-right .form-search .input-append button {
+  width: 50px !important;
+  height: 36px !important;
+  float: left;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -ms-box-sizing: border-box;
+  box-sizing: border-box;
+}
+.navbar.sticky-navbar .nav-right #sticky-nav-search.show .input-append {
+  position: absolute;
+  opacity: 1;
+  visibility: visible;
+}
+.navbar.sticky-navbar .nav-right #sticky-nav-search.show .input-append,
+.navbar.sticky-navbar .nav-right #sticky-nav-search.show .toggle {
+  background-color: #343434;
+  color: #ffffff;
+}
+.navbar.sticky-navbar .nav-left > ul {
+  margin: 0;
+  padding: 0;
+}
+@media (min-width: 769px) {
+  .navbar.sticky-navbar .nav-left {
+    display: none;
+  }
+}
+.navbar.sticky-navbar .site-name {
+  display: block;
+  color: #343434;
+}
+.navbar.sticky-navbar .site-name a {
+  font-weight: bold;
+  padding: 0 10px 0 0;
+  color: #ffffff;
+  max-width: 214px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+.navbar.sticky-navbar .site-name a:hover {
+  background-color: transparent;
+  color: #ffffff;
+  text-decoration: none;
+}
+.navbar.sticky-navbar .nav-right {
+  float: right;
+}
+.navbar.sticky-navbar .nav-right #header-extras {
+  float: left;
+  margin: 0;
+}
+.navbar.sticky-navbar .nav-right #header-extras a.donate-link:hover {
+  background: transparent;
+}
+@media (max-width: 768px) {
+  .navbar.sticky-navbar li.dropdown .dropdown-menu li a {
+    line-height: 56px;
+  }
+  .navbar.sticky-navbar .nav-shelf b.caret {
+    padding: 22px;
+  }
+}
+#menu-overflow > ul {
+  overflow-y: scroll;
+  max-height: 80vh;
+}
+#menu-overflow > ul .caret::before,
+#menu-overflow > ul .caret::after {
+  display: none;
+}
+#menu-overflow > ul ul.dropdown-menu {
+  position: relative;
+  border: none;
+  float: none;
+  box-shadow: none;
+}
+#menu-overflow > ul ul.dropdown-menu li a {
+  padding-left: 1.5em;
+}
+#menu-overflow > ul ul.dropdown-menu::before,
+#menu-overflow > ul ul.dropdown-menu::after {
+  display: none;
+}
+#menu-overflow > ul ul.dropdown-menu .sub-menu,
+#menu-overflow > ul ul.dropdown-menu .sub-sub-menu {
+  display: none;
+}
+@media (max-width: 769px) {
+  #sticky-nav .nav-shelf li,
+  #sticky-nav .nav-shelf li a {
+    color: #484848;
+  }
+  #sticky-nav .nav-shelf li:hover,
+  #sticky-nav .nav-shelf li a:hover {
+    color: #484848;
+    background-color: #fcd9c1;
+  }
+}
+.navbar li.home-icon > a img {
+  max-height: auto;
+  height: 44px;
+}
+.sticky-nav-holder {
+  border-bottom: none;
+}
 .site-hero {
   width: 100%;
   text-align: center;
@@ -424,10 +750,6 @@ body.normal.page #content.guide-page {
   padding: 24px 36px;
   font-size: 18px;
   margin-bottom: 0.5em;
-}
-#main-nav.navbar {
-  border-top: none;
-  border-bottom: none;
 }
 .footer-bg {
   background: transparent;
@@ -457,6 +779,10 @@ body.normal.page #content.guide-page {
 }
 /*** Largo-Re-Design ***/
 /* Navigation Bar */
+nav#largo-nav {
+  background-color: #f48030;
+  padding: 0 2.5%;
+}
 nav#largo-nav img {
   max-width: 200px;
   display: inline-block;
@@ -464,7 +790,6 @@ nav#largo-nav img {
   margin: 20px 100px 20px 100px;
 }
 nav#largo-nav div.navbar-inner {
-  background-color: #f48030;
   float: none;
 }
 nav#largo-nav ul {
@@ -487,9 +812,6 @@ nav#largo-nav ul#navbar-right {
   float: right;
   margin: 0;
 }
-nav#largo-nav #hamburger {
-  margin: 0;
-}
 nav#largo-nav a.btn-navbar:hover {
   background-color: #f2690d;
 }
@@ -507,30 +829,6 @@ nav#largo-nav .btn-navbar .bars .icon-bar {
   width: 18px;
   height: 3px;
   margin-top: 3px;
-}
-nav#largo-nav .nav-shelf {
-  display: none;
-  color: black;
-  border-bottom: #aaaaaa 1px solid;
-}
-nav#largo-nav .nav-shelf ul {
-  margin: 0;
-}
-nav#largo-nav .nav-shelf .nav li {
-  display: block;
-  margin: 0;
-}
-nav#largo-nav .nav-shelf .nav li:hover {
-  background-color: #f2f2f2;
-}
-nav#largo-nav .nav-shelf ul li a {
-  color: black;
-  line-height: 56px;
-  display: block;
-  padding-left: 25px;
-}
-nav#largo-nav .nav-shelf ul li a:hover {
-  text-decoration: none;
 }
 /* Sections - Hide these parts */
 div.site-hero {
@@ -806,6 +1104,8 @@ nav#largo-footer ul li a {
   }
   nav#largo-nav ul li {
     font-size: 1em;
+    margin-right: 15px;
+    margin-left: 15px;
   }
   nav#largo-nav ul {
     margin: 12px;
@@ -888,10 +1188,22 @@ nav#largo-footer ul li a {
     width: 300px;
   }
 }
-@media (max-width: 650px) {
+@media (max-width: 769px) {
   nav#largo-nav img {
-    margin-top: 15px;
+    height: 44px;
+    margin: 6px 0 6px 0;
   }
+  nav#largo-nav ul {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+  nav#largo-nav ul li {
+    margin-top: 0;
+    margin-bottom: 0;
+    line-height: 56px;
+  }
+}
+@media (max-width: 650px) {
   nav#largo-nav ul#navbar-left {
     display: none;
   }

--- a/wp-content/themes/largoproject/functions.php
+++ b/wp-content/themes/largoproject/functions.php
@@ -36,3 +36,22 @@ function largo_child_stylesheet() {
 	wp_enqueue_style( 'largoproject', get_stylesheet_directory_uri() . '/css/style.css' );
 }
 add_action( 'wp_enqueue_scripts', 'largo_child_stylesheet', 20 );
+
+/**
+ * Put the sticky nav logo in the main nav
+ */
+function largoproject_main_nav_logo() {
+	if ( of_get_option('sticky_header_logo') !== '') { ?>
+		<li class="home-icon">
+			<a href="<?php echo esc_url( home_url( '/' ) ); ?>">
+				<?php
+				if ( of_get_option( 'sticky_header_logo' ) !== '' )
+					largo_home_icon( 'icon-white' , 'orig' );
+				?>
+			</a>
+		</li>
+	<?php } else { ?>
+		<li class="site-name"><a href="/"><?php echo $site_name; ?></a></li>
+	<?php }
+}
+add_action( 'largo_before_main_nav_shelf', 'largoproject_main_nav_logo' );

--- a/wp-content/themes/largoproject/homepages/assets/css/largo.css
+++ b/wp-content/themes/largoproject/homepages/assets/css/largo.css
@@ -1,6 +1,3 @@
-.home #main-nav {
-  display: none;
-}
 .homepage-content .row-fluid {
   padding-bottom: 1em;
   margin-bottom: 3em;

--- a/wp-content/themes/largoproject/homepages/assets/css/largo.css
+++ b/wp-content/themes/largoproject/homepages/assets/css/largo.css
@@ -1,3 +1,6 @@
+.home #main-nav {
+  display: none;
+}
 .homepage-content .row-fluid {
   padding-bottom: 1em;
   margin-bottom: 3em;

--- a/wp-content/themes/largoproject/homepages/assets/less/largo.less
+++ b/wp-content/themes/largoproject/homepages/assets/less/largo.less
@@ -2,11 +2,6 @@
 @largoorange: #f48030;
 @largoyellow: #ffcf73;
 
-// This is because we have a custom nav set up, #largo-nav
-.home #main-nav {
-  display: none;
-}
-
 .homepage-content {
   .row-fluid {
     padding-bottom: 1em;

--- a/wp-content/themes/largoproject/homepages/assets/less/largo.less
+++ b/wp-content/themes/largoproject/homepages/assets/less/largo.less
@@ -2,6 +2,11 @@
 @largoorange: #f48030;
 @largoyellow: #ffcf73;
 
+// This is because we have a custom nav set up, #largo-nav
+.home #main-nav {
+  display: none;
+}
+
 .homepage-content {
   .row-fluid {
     padding-bottom: 1em;

--- a/wp-content/themes/largoproject/homepages/templates/largo.php
+++ b/wp-content/themes/largoproject/homepages/templates/largo.php
@@ -16,18 +16,6 @@
 						largo_nav_menu( $args );
 					?>
 				</ul>
-				<ul id="navbar-right">
-					<li id="hamburger">
-						<!-- "hamburger" buttoån (3 bars) to trigger off-canvas navigation -->
-						<a class="btn-navbar toggle-nav-bar" title="More" onclick="myFunction()">
-							<div class="bars">
-								<span class="icon-bar"></span>
-								<span class="icon-bar"></span>
-								<span class="icon-bar"></span>
-							</div>
-						</a>
-					</li>
-				</ul>
 			</div>
 		</div>
 	</nav>

--- a/wp-content/themes/largoproject/homepages/templates/largo.php
+++ b/wp-content/themes/largoproject/homepages/templates/largo.php
@@ -4,10 +4,17 @@
 			<div class="navbar-inner clearfix">
 				<img src="<?php echo get_stylesheet_directory_uri(); ?>/homepages/assets/img/logos/Largo__white_horiz2.png" />
 				<ul id="navbar-left">
-					<li><a href="#">Overview</a></li>
-					<li><a href="#">Docs</a></li>
-					<li><a href="#">Source</a></li>
-					<li><a href="#">Help</a></li>
+					<?php
+						$args = array(
+							'theme_location' => 'main-nav',
+							'depth' => 0,
+							'container' => false,
+							'items_wrap' => '%3$s',
+							'menu_class' => 'nav',
+							'walker' => new Bootstrap_Walker_Nav_Menu()
+						);
+						largo_nav_menu( $args );
+					?>
 				</ul>
 				<ul id="navbar-right">
 					<li id="hamburger">
@@ -20,14 +27,6 @@
 							</div>
 						</a>
 					</li>
-				</ul>
-			</div>
-			<div class="nav-shelf" style="top: 59px;">
-				<ul class="nav">
-					<li><a href="#">Overview</a></li>
-					<li><a href="#">Docs</a></li>
-					<li><a href="#">Source</a></li>
-					<li><a href="#">Help</a></li>
 				</ul>
 			</div>
 		</div>
@@ -250,10 +249,17 @@
 	<nav id="largo-footer" class="clearfix">
 		<div class="navbar-inner clearfix">
 			<ul>
-				<li><a href="#">Overview</a></li>
-				<li><a href="#">Docs</a></li>
-				<li><a href="#">Source</a></li>
-				<li><a href="#">Help</a></li>
+					<?php
+						$args = array(
+							'theme_location' => 'main-nav',
+							'depth' => 0,
+							'container' => false,
+							'items_wrap' => '%3$s',
+							'menu_class' => 'nav',
+							'walker' => new Bootstrap_Walker_Nav_Menu()
+						);
+						largo_nav_menu( $args );
+					?>
 			</ul>
 			<img src="<?php echo get_stylesheet_directory_uri(); ?>/homepages/assets/img/logos/INN-Logo-Primary-White-240x80.png" />
 		</div>

--- a/wp-content/themes/largoproject/homepages/templates/largo.php
+++ b/wp-content/themes/largoproject/homepages/templates/largo.php
@@ -1,24 +1,4 @@
 <div id="content" class="homepage-content clearfix span12">
-	<nav id="largo-nav" class="clearfix">
-		<div class="clearfix">
-			<div class="navbar-inner clearfix">
-				<img src="<?php echo get_stylesheet_directory_uri(); ?>/homepages/assets/img/logos/Largo__white_horiz2.png" />
-				<ul id="navbar-left">
-					<?php
-						$args = array(
-							'theme_location' => 'main-nav',
-							'depth' => 0,
-							'container' => false,
-							'items_wrap' => '%3$s',
-							'menu_class' => 'nav',
-							'walker' => new Bootstrap_Walker_Nav_Menu()
-						);
-						largo_nav_menu( $args );
-					?>
-				</ul>
-			</div>
-		</div>
-	</nav>
 	<section id="largo-hero" class="clearfix">
 		<div id="logo-and-description" class="clearfix">
 			<div id="hero-logo">

--- a/wp-content/themes/largoproject/less/_nav.less
+++ b/wp-content/themes/largoproject/less/_nav.less
@@ -37,3 +37,116 @@
 .sticky-nav-holder {
   border-bottom: none;
 }
+
+
+/**************
+ * random copied stuff pre-transition
+ */
+
+/* Navigation Bar */
+
+nav#main-nav {
+  background-color: @largoorange;
+  padding: 0 2.5%;
+
+  img {
+    max-width: 200px;
+    display: inline-block;
+    float: left;
+    margin: 20px 100px 20px 100px;
+  }
+
+  div.navbar-inner {
+    float: none;
+  }
+
+  ul {
+    margin: 20px;
+  }
+
+  ul li {
+    display: inline-block;
+    margin-top: 16px;
+    margin-right: 30px;
+    font-size: 1.2em;
+    a {
+      color: white;
+      font-weight: 300;
+    }
+  }
+
+  ul#navbar-left {
+    float: left;
+  }
+
+  ul#navbar-right {
+    float: right;
+    margin: 0;
+  }
+
+  a.btn-navbar:hover {
+    background-color: #f2690d;
+  }
+
+  .btn-navbar {
+    display: none;
+    padding: 0 20px;
+    line-height: 69px;
+    .bars {
+      display: inline-block;
+      .icon-bar {
+        background-color: white;
+        display: block;
+        width: 18px;
+        height: 3px;
+        margin-top: 3px;
+      }
+    }
+  }
+}
+@media (max-width: 1000px) {
+  nav#main-nav {
+    img {
+      margin: 2% 8% 2% 8%;
+      max-width: 150px;
+    }
+    ul li {
+      font-size: 1em;
+      margin-right: 15px;
+      margin-left: 15px;
+    }
+    ul {
+      margin: 12px;
+    }
+  }
+}
+@media (max-width: 769px) {
+  nav#main-nav {
+    img {
+      height: 44px;
+      margin: 6px 0 6px 0;
+    }
+
+    ul {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+    ul li {
+      margin-top: 0;
+      margin-bottom: 0;
+      line-height: @stickyNavLineHeight;
+    }
+  }
+}
+@media (max-width: 650px) {
+  nav#main-nav {
+
+    ul#navbar-left {
+      display: none;
+    }
+
+    .btn-navbar {
+      display: block;
+    }
+  }
+}

--- a/wp-content/themes/largoproject/less/_nav.less
+++ b/wp-content/themes/largoproject/less/_nav.less
@@ -53,10 +53,6 @@
   }
 }
 
-/**************
- * random copied stuff pre-transition
- */
-
 /* Navigation Bar */
 
 #main-nav {

--- a/wp-content/themes/largoproject/less/_nav.less
+++ b/wp-content/themes/largoproject/less/_nav.less
@@ -1,0 +1,39 @@
+// These copied from Largo/less/inc/variables.less
+@grayLighter:           #ddd;
+@white: #fff;
+@grayDark:              #484848;
+
+@bodyBackground:        @white;
+
+// Change all the sticky nav colors
+@baseColor: @white; //? This is the Largo Blue in Largo
+@stickyNavbarBackgroundColor: @largoorange;
+@stickyNavbarText: @white;
+@stickyNavbarLinkColor: @stickyNavbarText;
+@stickyNavbarLinkColorHover: lighten(@stickyNavbarLinkColor, 5%);
+@stickyNavbarDropdownCaretColor: @stickyNavbarLinkColor;
+@stickyNavbarDropdownCaretColorHover: lighten(@stickyNavbarLinkColor, 5%);
+
+@import "../../largo/less/inc/mixins.less";
+@import "../../largo/less/inc/navbar-sticky.less";
+
+@media (max-width: 769px) {
+  #sticky-nav .nav-shelf {
+    li, li a {
+      color: @grayDark;
+
+      &:hover {
+        color: @grayDark;
+        background-color: lighten( @largoorange, 30% );
+      }
+    }
+  }
+}
+.navbar li.home-icon > a img {
+  max-height: auto;
+  height: 44px;
+}
+
+.sticky-nav-holder {
+  border-bottom: none;
+}

--- a/wp-content/themes/largoproject/less/_nav.less
+++ b/wp-content/themes/largoproject/less/_nav.less
@@ -29,15 +29,29 @@
     }
   }
 }
-.navbar li.home-icon > a img {
-  max-height: auto;
-  height: 44px;
-}
 
 .sticky-nav-holder {
   border-bottom: none;
 }
 
+.navbar.sticky-navbar {
+  li > a:hover {
+    background-color: @darklargoorange;
+  }
+  li.home-icon {
+    > a img {
+      // this is a shim to take account for the fact that the text in the image is not quite vertically centered.
+      vertical-align: -25%;
+      height: 44px;
+    }
+  }
+
+  li.dropdown .dropdown-menu {
+    li a {
+      color: @grayDark;
+    }
+  }
+}
 
 /**************
  * random copied stuff pre-transition
@@ -45,15 +59,13 @@
 
 /* Navigation Bar */
 
-nav#main-nav {
+#main-nav {
   background-color: @largoorange;
   padding: 0 2.5%;
 
   img {
-    max-width: 200px;
     display: inline-block;
     float: left;
-    margin: 20px 100px 20px 100px;
   }
 
   div.navbar-inner {
@@ -66,13 +78,17 @@ nav#main-nav {
 
   ul li {
     display: inline-block;
-    margin-top: 16px;
     margin-right: 30px;
     font-size: 1.2em;
     a {
       color: white;
       font-weight: 300;
     }
+  }
+
+  li > a:hover {
+    background-color: @largoorange;
+    text-decoration: underline;
   }
 
   ul#navbar-left {
@@ -104,24 +120,39 @@ nav#main-nav {
     }
   }
 }
-@media (max-width: 1000px) {
-  nav#main-nav {
+@media (min-width: 1001px) {
+  #main-nav {
     img {
-      margin: 2% 8% 2% 8%;
+      max-width: 200px;
+      margin: 20px 100px 20px 100px;
+    }
+    .nav {
+      float: right;
+    }
+    .nav li a {
+      line-height: 58px;
+    }
+  }
+}
+@media (max-width: 1000px) {
+  #main-nav {
+    img {
       max-width: 150px;
+      height: 40px;
     }
     ul li {
       font-size: 1em;
       margin-right: 15px;
       margin-left: 15px;
     }
+    .home-icon,
     ul {
       margin: 12px;
     }
   }
 }
 @media (max-width: 769px) {
-  nav#main-nav {
+  #main-nav {
     img {
       height: 44px;
       margin: 6px 0 6px 0;
@@ -137,9 +168,14 @@ nav#main-nav {
       line-height: @stickyNavLineHeight;
     }
   }
+
+  .navbar.sticky-navbar li.home-icon a img {
+    // undo the shim, because the text does not appear here.
+    vertical-align: middle;
+  }
 }
 @media (max-width: 650px) {
-  nav#main-nav {
+  #main-nav {
 
     ul#navbar-left {
       display: none;

--- a/wp-content/themes/largoproject/less/style.less
+++ b/wp-content/themes/largoproject/less/style.less
@@ -58,67 +58,6 @@
 
 /*** Largo-Re-Design ***/
 
-/* Navigation Bar */
-
-nav#largo-nav {
-  background-color: @largoorange;
-  padding: 0 2.5%;
-
-  img {
-    max-width: 200px;
-    display: inline-block;
-    float: left;
-    margin: 20px 100px 20px 100px;
-  }
-
-  div.navbar-inner {
-    float: none;
-  }
-
-  ul {
-    margin: 20px;
-  }
-
-  ul li {
-    display: inline-block;
-    margin-top: 16px;
-    margin-right: 30px;
-    font-size: 1.2em;
-    a {
-      color: white;
-      font-weight: 300;
-    }
-  }
-
-  ul#navbar-left {
-    float: left;
-  }
-
-  ul#navbar-right {
-    float: right;
-    margin: 0;
-  }
-
-  a.btn-navbar:hover {
-    background-color: #f2690d;
-  }
-
-  .btn-navbar {
-    display: none;
-    padding: 0 20px;
-    line-height: 69px;
-    .bars {
-      display: inline-block;
-      .icon-bar {
-        background-color: white;
-        display: block;
-        width: 18px;
-        height: 3px;
-        margin-top: 3px;
-      }
-    }
-  }
-}
 
 /* Sections - Hide these parts */
 
@@ -457,20 +396,6 @@ nav#largo-footer {
 }
 
 @media (max-width: 1000px) {
-  nav#largo-nav {
-    img {
-      margin: 2% 8% 2% 8%;
-      max-width: 150px;
-    }
-    ul li {
-      font-size: 1em;
-      margin-right: 15px;
-      margin-left: 15px;
-    }
-    ul {
-      margin: 12px;
-    }
-  }
 
   div.max-width-container {
     margin: 0 20px;
@@ -572,36 +497,7 @@ nav#largo-footer {
   }
 }
 
-@media (max-width: 769px) {
-  nav#largo-nav {
-    img {
-      height: 44px;
-      margin: 6px 0 6px 0;
-    }
-
-    ul {
-      margin-top: 0;
-      margin-bottom: 0;
-    }
-    ul li {
-      margin-top: 0;
-      margin-bottom: 0;
-      line-height: @stickyNavLineHeight;
-    }
-  }
-}
 @media (max-width: 650px) {
-  
-  nav#largo-nav {
-
-    ul#navbar-left {
-      display: none;
-    }
-
-    .btn-navbar {
-      display: block;
-    }
-  }
 
   section#largo-hero {
     div#hero-description {

--- a/wp-content/themes/largoproject/less/style.less
+++ b/wp-content/themes/largoproject/less/style.less
@@ -1,6 +1,7 @@
 @import "../../inn/less/variables.less";
 @import "../../inn/less/common.less";
 @largoorange: #f48030;
+@darklargoorange: darken( @largoorange, 10% );
 @largoyellow: #ffcf73;
 @import "resources-page.less";
 @import "_nav.less";

--- a/wp-content/themes/largoproject/less/style.less
+++ b/wp-content/themes/largoproject/less/style.less
@@ -3,6 +3,7 @@
 @largoorange: #f48030;
 @largoyellow: #ffcf73;
 @import "resources-page.less";
+@import "_nav.less";
 
 .site-hero {
   width: 100%;
@@ -24,10 +25,6 @@
 	font-size: 18px;
     margin-bottom: 0.5em;
   }
-}
-#main-nav.navbar {
-  border-top: none;
-  border-bottom: none;
 }
 .footer-bg {
   background: transparent;
@@ -64,6 +61,8 @@
 /* Navigation Bar */
 
 nav#largo-nav {
+  background-color: @largoorange;
+  padding: 0 2.5%;
 
   img {
     max-width: 200px;
@@ -73,7 +72,6 @@ nav#largo-nav {
   }
 
   div.navbar-inner {
-    background-color: @largoorange;
     float: none;
   }
 
@@ -101,10 +99,6 @@ nav#largo-nav {
     margin: 0;
   }
 
-  #hamburger {
-    margin: 0;
-  }
-
   a.btn-navbar:hover {
     background-color: #f2690d;
   }
@@ -121,32 +115,6 @@ nav#largo-nav {
         width: 18px;
         height: 3px;
         margin-top: 3px;
-      }
-    }
-  }
-
-  .nav-shelf {
-    display: none;
-    color: black;
-    border-bottom: #aaaaaa 1px solid;
-    ul {
-      margin: 0;
-    }
-    .nav li {
-      display: block;
-      margin: 0;
-      &:hover {
-        background-color: #f2f2f2;
-      }
-    }
-
-    ul li a {
-      color: black;
-      line-height: 56px;
-      display: block;
-      padding-left: 25px;
-      &:hover {
-        text-decoration:none;
       }
     }
   }
@@ -493,9 +461,11 @@ nav#largo-footer {
     img {
       margin: 2% 8% 2% 8%;
       max-width: 150px;
-    } 
+    }
     ul li {
       font-size: 1em;
+      margin-right: 15px;
+      margin-left: 15px;
     }
     ul {
       margin: 12px;
@@ -602,13 +572,27 @@ nav#largo-footer {
   }
 }
 
+@media (max-width: 769px) {
+  nav#largo-nav {
+    img {
+      height: 44px;
+      margin: 6px 0 6px 0;
+    }
+
+    ul {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+    ul li {
+      margin-top: 0;
+      margin-bottom: 0;
+      line-height: @stickyNavLineHeight;
+    }
+  }
+}
 @media (max-width: 650px) {
   
   nav#largo-nav {
-
-    img {
-      margin-top: 15px;
-    }
 
     ul#navbar-left {
       display: none;


### PR DESCRIPTION
## Changes

- Puts the sticky header logo in the main nav
- Removes `#largo-nav`, replacing hardcoded navs with the Main Menu
- Moves styles for `#largo-nav` onto `#main-nav`
    - defines new color `@darklargoorange` for hover states for menus
    - Moves most nav styles into largoproject/less/_nav.less

Note: this contains some shims for the file https://github.com/INN/umbrella-inndev/blob/gabe-largo/wp-content/themes/largoproject/homepages/assets/img/logos/Largo__white_horiz2.png so that it appears more-centered compared to the vertically-centered text of the main navigation in the sticky nav.

<img width="420" alt="screen shot 2017-01-26 at 9 16 06 pm" src="https://cloud.githubusercontent.com/assets/1754187/22358540/f6080e6e-e40d-11e6-9221-437392de65d3.png">
<img width="940" alt="screen shot 2017-01-26 at 9 25 08 pm" src="https://cloud.githubusercontent.com/assets/1754187/22358541/f608e816-e40d-11e6-8aba-305e1f6344dd.png">

We may want to edit that file and remove the shims, which are helpfully tagged with "shim" in the comments in `less/_nav.less`
