### PR TITLE
Largoproject nav color sizing fixes

### DIFF
--- a/wp-content/themes/largoproject/css/style.css
+++ b/wp-content/themes/largoproject/css/style.css
@@ -947,7 +947,7 @@ header#site-header {
 div#main {
   margin: 0;
 }
-@media (min-width: 769px) {
+@media (min-width: 783px) {
   div#main {
     padding-top: 5em;
   }

--- a/wp-content/themes/largoproject/css/style.css
+++ b/wp-content/themes/largoproject/css/style.css
@@ -585,7 +585,7 @@ body.admin-bar .sticky-nav-holder {
 #menu-overflow > ul ul.dropdown-menu .sub-sub-menu {
   display: none;
 }
-@media (max-width: 769px) {
+@media (max-width: 768px) {
   #sticky-nav .nav-shelf li,
   #sticky-nav .nav-shelf li a {
     color: #484848;
@@ -689,7 +689,7 @@ body.admin-bar .sticky-nav-holder {
     margin: 12px;
   }
 }
-@media (max-width: 769px) {
+@media (max-width: 768px) {
   #main-nav img {
     height: 44px;
     margin: 6px 0 6px 0;
@@ -715,7 +715,7 @@ body.admin-bar .sticky-nav-holder {
     display: block;
   }
 }
-@media (min-width: 769px) and (max-width: 900px) {
+@media (min-width: 768px) and (max-width: 900px) {
   .global-nav .nav-right .donate-btn {
     display: none;
   }

--- a/wp-content/themes/largoproject/less/_nav.less
+++ b/wp-content/themes/largoproject/less/_nav.less
@@ -21,7 +21,7 @@
 @import "../../largo/less/inc/mixins.less";
 @import "../../largo/less/inc/navbar-sticky.less";
 
-@media (max-width: 769px) {
+@media (max-width: 768px) {
   #sticky-nav .nav-shelf {
     li, li a {
       color: @grayDark;
@@ -151,7 +151,7 @@
     }
   }
 }
-@media (max-width: 769px) {
+@media (max-width: 768px) {
   #main-nav {
     img {
       height: 44px;
@@ -187,7 +187,7 @@
   }
 }
 
-@media (min-width: 769px) and (max-width: 900px) {
+@media (min-width: 768px) and (max-width: 900px) {
   // this because otherwise the navs start wrapping and everything breaks unpleasantly.
   .global-nav .nav-right .donate-btn {
     display: none;

--- a/wp-content/themes/largoproject/less/resources-page.less
+++ b/wp-content/themes/largoproject/less/resources-page.less
@@ -77,7 +77,7 @@ body.normal.page #content.guide-page {
       background-color: @xdkgray;
     }
   }
-  @media screen and (max-width:782px) {
+  @media screen and (max-width: @sideNavCollapse) {
     .guide-nav {
       width: 100%;
       padding: 0;
@@ -133,7 +133,7 @@ body.normal.page #content.guide-page {
     padding-right: 24px;
     box-sizing: border-box;
   }
-  @media screen and (max-width:782px) {
+  @media screen and (max-width: @sideNavCollapse) {
     article.span9 {
       width: 100%;
       margin-left: 0;

--- a/wp-content/themes/largoproject/less/style.less
+++ b/wp-content/themes/largoproject/less/style.less
@@ -5,6 +5,9 @@
 @darklargoorange: darken( @largoorange, 10% );
 @largoyellow: #ffcf73;
 
+// max-width at which the side nav will collapse down into 
+@sideNavCollapse: 782px;
+
 @import "_nav.less";
 @import "_footer.less";
 @import "resources-page.less";
@@ -46,7 +49,8 @@ header#site-header {
 }
 
 div#main {
-  @media (min-width:769px) {
+  // less is apparently very particular about the spacing in this line; else it will not do the math
+  @media (min-width: (@sideNavCollapse + 1) ) {
     padding-top: 5em;
   }
   margin: 0;


### PR DESCRIPTION
## changes

- switches to `768px` for the max-width of nav stuff
    - fixes the font color on sticky nav
    - fixes font vertical alignment on sticky nav
- creates new variable `@sideNavCollapse` for use as the width at which the nav on project pages collapses, and uses that to fix the padding-top problems on `#main`