### PR TITLE
Copy single-page styles over to 404 page; create 404 template

### DIFF
--- a/wp-content/themes/largoproject/404.php
+++ b/wp-content/themes/largoproject/404.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * The template for displaying 404 pages.
+ *
+ * @package Largo
+ * @since 0.1
+ */
+get_header(); ?>
+
+<div id="content" class="span12" role="main">
+	<?php get_template_part( 'partials/content', 'not-found' ); ?>
+</div><!--#content -->
+
+<?php get_footer();

--- a/wp-content/themes/largoproject/css/style.css
+++ b/wp-content/themes/largoproject/css/style.css
@@ -1123,6 +1123,27 @@ section#self-help #user-guides #btn-author:hover {
     margin-top: 8px;
   }
 }
+/**
+ * This copies a bunch of stuff from largo/less/single.less
+ */
+body.error404 header {
+  clear: both;
+  margin: 24px 17.0213%;
+  position: relative;
+}
+@media only screen and (max-width: 979px) {
+  body.error404 header {
+    margin: 24px 6.38297872%;
+  }
+}
+body.error404 .entry-content {
+  padding: 0 17.021276594%;
+}
+@media only screen and (max-width: 979px) {
+  body.error404 .entry-content {
+    padding: 0 6.38297872%;
+  }
+}
 .site-hero {
   width: 100%;
   text-align: center;

--- a/wp-content/themes/largoproject/less/404.less
+++ b/wp-content/themes/largoproject/less/404.less
@@ -1,0 +1,21 @@
+/**
+ * This copies a bunch of stuff from largo/less/single.less
+ */
+@tabletDown:  ~"only screen and (max-width: 979px)";
+@fluidGridColumnWidth:    6.382978723%;
+body.error404 {
+  header {
+    clear: both;
+    margin: 24px 17.0213%;
+    position: relative;
+    @media @tabletDown {
+      margin: 24px @fluidGridColumnWidth;
+    }
+  }
+  .entry-content {
+    padding: 0 17.021276594%;
+    @media @tabletDown {
+      padding: 0 @fluidGridColumnWidth;
+    }
+  }
+}

--- a/wp-content/themes/largoproject/less/style.less
+++ b/wp-content/themes/largoproject/less/style.less
@@ -13,6 +13,7 @@
 @import "_footer.less";
 @import "resources-page.less";
 @import "support-page.less";
+@import "404.less";
 
 .site-hero {
   width: 100%;


### PR DESCRIPTION
## Changes

Creates new 404 page template for the Largo docs site:
- no sidebar
- no Largo Recent Posts widget
- borrows single-column page template styles from Largo

<img width="965" alt="screen shot 2017-02-09 at 11 20 43 am" src="https://cloud.githubusercontent.com/assets/1754187/22792177/e72ce58e-eeb9-11e6-9c13-af93ae98fd4d.png">
<img width="429" alt="screen shot 2017-02-09 at 11 20 54 am" src="https://cloud.githubusercontent.com/assets/1754187/22792178/e73ad356-eeb9-11e6-8b1d-f20e3a34c607.png">

## Questions:

What else should we have on our 404 page? I'm asking the Write The Docs slack for good 404 pages on docs sites, but we may have INN-specific things that we should include.