### PR TITLE
Bump the Largo version number to 0.5.5.4 in all references on largo.inn.org

### DIFF
--- a/wp-content/themes/largoproject/homepages/templates/largo.php
+++ b/wp-content/themes/largoproject/homepages/templates/largo.php
@@ -3,7 +3,7 @@
 		<div id="logo-and-description" class="clearfix">
 			<div id="hero-logo">
 				<img src="<?php echo get_stylesheet_directory_uri(); ?>/homepages/assets/img/logos/largo-project-logo.svg" />
-				<span id="version">Version 0.5.5.3<span>
+				<span id="version">Version 0.5.5.4<span>
 			</div>
 			<div id="hero-description">
 				<h4>The WordPress Framework for News Websites</h4>

--- a/wp-content/themes/largoproject/partials/largo-hero.php
+++ b/wp-content/themes/largoproject/partials/largo-hero.php
@@ -4,7 +4,7 @@
 <div class="site-hero">
 	<img src="<?php echo get_stylesheet_directory_uri(); ?>/img/largo-sq.png" />
 	<h3 class="tagline">The WordPress Framework for News Websites</h3>
-	<a class="btn" href="https://github.com/INN/Largo/archive/v0.5.5.3.zip">Download Largo</a>
-	<p class="version">Version 0.5.5.3</p>
+	<a class="btn" href="https://github.com/INN/Largo/archive/v0.5.5.4.zip">Download Largo</a>
+	<p class="version">Version 0.5.5.4</p>
 </div>
 <?php }


### PR DESCRIPTION
Largo 0.5.5.4 came out in October 26, 2017, but we never bumped the version number. This fixes that.