### PR TITLE
INN Multi RSS Importer: If catOptions isn't countable, don't try to count it

### DIFF
--- a/wp-content/plugins/inn-rss-multi-importer/inc/upgrade.php
+++ b/wp-content/plugins/inn-rss-multi-importer/inc/upgrade.php
@@ -96,8 +96,13 @@ function upgrade_db() {
 			}
 		}
 
-		$catsize = count($catOptions);
-		$postoptionsize= $catsize/2;
+		if ( is_array( $catOptions ) ) {
+			$catsize = count($catOptions);
+			$postoptionsize = $catsize/2;
+		} else {
+			$catsize = 0;
+			$postoptionsize = 0;
+		}
 
 		for ( $q=1; $q<=$postoptionsize; $q++ ){
 			$post_settings['categoryid']['plugcatid'][$q]=$post_options['categoryid']['plugcatid'][$q];


### PR DESCRIPTION
This is a fix for a PHP warning that will be an error in 7.3, affecting all pages.