### PR TITLE
Custom sidebar updates for guides template

### DIFF
--- a/wp-content/themes/cjet/css/style.css
+++ b/wp-content/themes/cjet/css/style.css
@@ -474,30 +474,3 @@ body.normal.page #content.guide-page {
 .guide-page .guide-nav ul li a {
   color: #1c1c1c;
 }
-.guide-page .resources {
-  border: 3px solid #ff8b4d;
-  padding: 15px;
-  margin-bottom: 40px;
-}
-.guide-page .resources h4 {
-  margin: 5px 0;
-  color: #1c1c1c;
-  text-transform: uppercase;
-}
-.guide-page .resources ul.guide-resources {
-  margin-bottom: 0;
-}
-.guide-page .resources ul.guide-resources li {
-  display: inline-grid;
-  width: 25%;
-  margin: 10px 0 0;
-  font-size: 16px;
-}
-.guide-page .resources ul.guide-resources li i {
-  display: none;
-}
-@media (max-width: 999px) {
-  .guide-page .resources ul.guide-resources li {
-    width: 100%;
-  }
-}

--- a/wp-content/themes/cjet/css/style.css
+++ b/wp-content/themes/cjet/css/style.css
@@ -458,3 +458,46 @@ body.normal.page #content.guide-page {
     display: none;
   }
 }
+.guide-page .guide-nav {
+  background-color: transparent;
+  border-right: 3px solid #ff8b4d;
+  padding-top: 0;
+}
+.guide-page .guide-nav h4 {
+  color: #0089bb;
+  margin-bottom: 15px;
+}
+.guide-page .guide-nav ul {
+  list-style: none;
+  margin-left: 0;
+}
+.guide-page .guide-nav ul li a {
+  color: #1c1c1c;
+}
+.guide-page .resources {
+  border: 3px solid #ff8b4d;
+  padding: 15px;
+  margin-bottom: 40px;
+}
+.guide-page .resources h4 {
+  margin: 5px 0;
+  color: #1c1c1c;
+  text-transform: uppercase;
+}
+.guide-page .resources ul.guide-resources {
+  margin-bottom: 0;
+}
+.guide-page .resources ul.guide-resources li {
+  display: inline-grid;
+  width: 25%;
+  margin: 10px 0 0;
+  font-size: 16px;
+}
+.guide-page .resources ul.guide-resources li i {
+  display: none;
+}
+@media (max-width: 999px) {
+  .guide-page .resources ul.guide-resources li {
+    width: 100%;
+  }
+}

--- a/wp-content/themes/cjet/css/style.css
+++ b/wp-content/themes/cjet/css/style.css
@@ -324,12 +324,15 @@ body.normal.page #content.guide-page {
 }
 .guide-page .guide-nav {
   padding: 20px;
-  background-color: #edf1f4;
+  background-color: transparent;
+  border-right: 3px solid #ff8b4d;
+  padding-top: 0;
 }
 .guide-page .guide-nav h4 {
   font-size: 18px;
-  margin-bottom: 8px;
   text-transform: uppercase;
+  color: #0089bb;
+  margin-bottom: 15px;
 }
 .guide-page .guide-nav h4 a {
   color: #555555;
@@ -339,6 +342,34 @@ body.normal.page #content.guide-page {
 }
 .guide-page .guide-nav .current_page_item .children {
   font-weight: normal;
+}
+.guide-page .guide-nav .guide-sidebar-below-toc-widget-area {
+  list-style: none;
+}
+.guide-page .guide-nav .guide-sidebar-below-toc-widget-area h2.widgettitle {
+  color: #1c1c1c;
+}
+@media (max-width: 768px) {
+  .guide-page .guide-nav .guide-sidebar-below-toc-widget-area {
+    display: none;
+  }
+}
+.guide-page .guide-nav ul {
+  margin-left: 0;
+}
+.guide-page .guide-nav ul.guide-tree {
+  list-style: none;
+}
+.guide-page .guide-nav ul.guide-tree li a {
+  color: #1c1c1c;
+}
+.guide-page .guide-nav ul .largo-donate h2 {
+  font-size: 17px;
+}
+.guide-page .guide-nav ul .largo-donate p {
+  margin-bottom: 26px;
+  font-size: 16px;
+  max-width: 95%;
 }
 .guide-page .guide-author {
   font-size: 18px;
@@ -395,7 +426,7 @@ body.normal.page #content.guide-page {
     float: none;
   }
   .guide-page .guide-nav li > a {
-    color: #09c9ff;
+    color: #0089bb;
     padding: 6px 10px;
   }
   .guide-page .guide-nav .resources h4 {
@@ -457,20 +488,4 @@ body.normal.page #content.guide-page {
   #breadcrumbs {
     display: none;
   }
-}
-.guide-page .guide-nav {
-  background-color: transparent;
-  border-right: 3px solid #ff8b4d;
-  padding-top: 0;
-}
-.guide-page .guide-nav h4 {
-  color: #0089bb;
-  margin-bottom: 15px;
-}
-.guide-page .guide-nav ul {
-  list-style: none;
-  margin-left: 0;
-}
-.guide-page .guide-nav ul li a {
-  color: #1c1c1c;
 }

--- a/wp-content/themes/cjet/guides.php
+++ b/wp-content/themes/cjet/guides.php
@@ -55,6 +55,25 @@ $top_page = FALSE;
 						<?php echo $children; ?>
 					</ul>
 
+					<?php
+					// on interior guide pages, list resources attached to the parent guide page
+					// if ( $attachments ) : ?>
+					<!-- <div class="resources">
+						<h4><?php _e('Related Resources', 'cjet'); ?></h4>
+						<ul class="guide-resources"><?php
+							// foreach ( $attachments as $attachment ) {
+							// 	//print_r( $attachment );
+							// 	$class = "mime-" . sanitize_title( $attachment->post_mime_type );
+							// 	echo '<li class="' . $class . ' data-design-thumbnail">';
+							// 	echo cjet_format_attachment_link( $attachment->ID );
+							// 	echo '</li>';
+							// }
+						?> -->
+						<!-- </ul></div> -->
+							<?php
+					// endif;	// resources links
+					?>
+
 				</div>
 			</nav>
 
@@ -81,25 +100,6 @@ $top_page = FALSE;
 						if ( $top_page && ( get_post_meta( $post->ID, 'cjet_hide_author', TRUE ) !== '1' ) ) {
 							the_widget( 'largo_author_widget' );
 						}
-					?>
-
-					<?php
-					// on interior guide pages, list resources attached to the parent guide page
-					if ( $attachments ) : ?>
-					<div class="resources">
-						<h4><?php _e('Related Resources', 'cjet'); ?></h4>
-						<ul class="guide-resources"><?php
-							foreach ( $attachments as $attachment ) {
-								//print_r( $attachment );
-								$class = "mime-" . sanitize_title( $attachment->post_mime_type );
-								echo '<li class="' . $class . ' data-design-thumbnail">';
-								echo cjet_format_attachment_link( $attachment->ID );
-								echo '</li>';
-							}
-						?>
-						</ul></div>
-							<?php
-					endif;	// resources links
 					?>
 
 					<?php // in-guide navigation ?>

--- a/wp-content/themes/cjet/guides.php
+++ b/wp-content/themes/cjet/guides.php
@@ -55,24 +55,6 @@ $top_page = FALSE;
 						<?php echo $children; ?>
 					</ul>
 
-					<?php
-					// on interior guide pages, list resources attached to the parent guide page
-					if ( $attachments ) : ?>
-					<div class="resources">
-						<h4><?php _e('Resources', 'cjet'); ?></h4>
-						<ul class="guide-resources"><?php
-							foreach ( $attachments as $attachment ) {
-								//print_r( $attachment );
-								$class = "mime-" . sanitize_title( $attachment->post_mime_type );
-								echo '<li class="' . $class . ' data-design-thumbnail">';
-								echo cjet_format_attachment_link( $attachment->ID );
-								echo '</li>';
-							}
-						?>
-						</ul></div>
-							<?php
-					endif;	// resources links
-					?>
 				</div>
 			</nav>
 
@@ -99,6 +81,25 @@ $top_page = FALSE;
 						if ( $top_page && ( get_post_meta( $post->ID, 'cjet_hide_author', TRUE ) !== '1' ) ) {
 							the_widget( 'largo_author_widget' );
 						}
+					?>
+
+					<?php
+					// on interior guide pages, list resources attached to the parent guide page
+					if ( $attachments ) : ?>
+					<div class="resources">
+						<h4><?php _e('Related Resources', 'cjet'); ?></h4>
+						<ul class="guide-resources"><?php
+							foreach ( $attachments as $attachment ) {
+								//print_r( $attachment );
+								$class = "mime-" . sanitize_title( $attachment->post_mime_type );
+								echo '<li class="' . $class . ' data-design-thumbnail">';
+								echo cjet_format_attachment_link( $attachment->ID );
+								echo '</li>';
+							}
+						?>
+						</ul></div>
+							<?php
+					endif;	// resources links
 					?>
 
 					<?php // in-guide navigation ?>

--- a/wp-content/themes/cjet/guides.php
+++ b/wp-content/themes/cjet/guides.php
@@ -45,7 +45,7 @@ $top_page = FALSE;
 			        <span class="icon-bar"></span>
 		        </div>
 		      </a>
-
+					
 					<?php if ( $top_page ) { ?>
 						<h4><?php _e('In This ' . ucfirst( rtrim($guide_type, 's') ), 'cjet'); ?></h4>
 					<?php } else { ?>
@@ -53,6 +53,10 @@ $top_page = FALSE;
 					<?php } ?>
 					<ul class="guide-tree">
 						<?php echo $children; ?>
+					</ul>
+					
+					<ul class="guide-sidebar-below-toc-widget-area">
+						<?php dynamic_sidebar( 'guide-sidebar-below-toc' ); ?>
 					</ul>
 
 					<?php

--- a/wp-content/themes/cjet/inc/sidebars.php
+++ b/wp-content/themes/cjet/inc/sidebars.php
@@ -9,5 +9,11 @@ function cjet_register_sidebars() {
 		'before_title' 	=> '<h3 class="widgettitle">',
 		'after_title' 	=> '</h3>',
 	) );
+
+	register_sidebar( array(
+		'name'			=> __( 'Guide Sidebar Below Table of Contents', 'cjet' ),
+		'id' 			=> 'guide-sidebar-below-toc',
+		'description' 	=> __( 'Widget area for Guides sidebar. This will appear below the table of contents.', 'cjet' ),
+	) );
 }
 add_action( 'widgets_init', 'cjet_register_sidebars' );

--- a/wp-content/themes/cjet/less/style.less
+++ b/wp-content/themes/cjet/less/style.less
@@ -208,31 +208,4 @@ body.normal.page #content.guide-page {
       }
     }
   }
-  .resources {
-    border: 3px solid @orange;
-    padding: 15px;
-    margin-bottom: 40px;
-    h4 {
-      margin: 5px 0;
-      color: #1c1c1c;
-      text-transform: uppercase;
-    }
-    ul{
-      &.guide-resources {
-        margin-bottom: 0;
-        li {
-          display: inline-grid;
-          width: 25%;
-          margin: 10px 0 0;
-          font-size: 16px;
-          i {
-            display: none;
-          }
-          @media (max-width: 999px) {
-            width: 100%;
-          }
-        }
-      }
-    }
-  }
 }

--- a/wp-content/themes/cjet/less/style.less
+++ b/wp-content/themes/cjet/less/style.less
@@ -51,20 +51,55 @@ body.normal.page #content.guide-page {
   }
   .guide-nav {
     padding: 20px;
-    background-color: @xltgray;
+    background-color: transparent;
+    border-right: 3px solid @orange;
+    padding-top: 0;
     h4 {
       font-size: 18px;
-      margin-bottom: 8px;
       text-transform: uppercase;
+      color: #0089bb;
+      margin-bottom:15px;
       a {
-	    color: @dkgray;
+        color: @dkgray;
       }
     }
     .current_page_item {
-	  font-weight: bold;
-	  .children {
-	    font-weight: normal;
-	  }
+      font-weight: bold;
+      .children {
+        font-weight: normal;
+      }
+    }
+    .guide-sidebar-below-toc-widget-area {
+      list-style: none;
+      h2 {
+        &.widgettitle {
+        color: #1c1c1c;
+        }
+      }
+      @media (max-width: 768px) {
+        display: none;
+      }
+    }
+    ul {
+      margin-left: 0;
+      &.guide-tree {
+        list-style: none;
+        li {
+          a {
+            color: #1c1c1c;
+          }
+        }
+      }
+      .largo-donate{
+        h2 {
+          font-size: 17px;
+        }
+        p {
+          margin-bottom: 26px;
+          font-size: 16px;
+          max-width: 95%;
+        }
+      }
     }
   }
   .guide-author {
@@ -186,26 +221,5 @@ body.normal.page #content.guide-page {
 @media screen and (max-width: 768px) {
   #breadcrumbs {
     display: none;
-  }
-}
-
-.guide-page {
-  .guide-nav {
-    background-color: transparent;
-    border-right: 3px solid @orange;
-    padding-top: 0;
-    h4 {
-      color: #0089bb;
-      margin-bottom:15px;
-    }
-    ul {
-      list-style: none;
-      margin-left: 0;
-      li {
-        a {
-          color: #1c1c1c;
-        }
-      }
-    }
   }
 }

--- a/wp-content/themes/cjet/less/style.less
+++ b/wp-content/themes/cjet/less/style.less
@@ -188,3 +188,51 @@ body.normal.page #content.guide-page {
     display: none;
   }
 }
+
+.guide-page {
+  .guide-nav {
+    background-color: transparent;
+    border-right: 3px solid @orange;
+    padding-top: 0;
+    h4 {
+      color: #0089bb;
+      margin-bottom:15px;
+    }
+    ul {
+      list-style: none;
+      margin-left: 0;
+      li {
+        a {
+          color: #1c1c1c;
+        }
+      }
+    }
+  }
+  .resources {
+    border: 3px solid @orange;
+    padding: 15px;
+    margin-bottom: 40px;
+    h4 {
+      margin: 5px 0;
+      color: #1c1c1c;
+      text-transform: uppercase;
+    }
+    ul{
+      &.guide-resources {
+        margin-bottom: 0;
+        li {
+          display: inline-grid;
+          width: 25%;
+          margin: 10px 0 0;
+          font-size: 16px;
+          i {
+            display: none;
+          }
+          @media (max-width: 999px) {
+            width: 100%;
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Per issue #76.

Before:
![Screen Shot 2019-05-31 at 12 50 05 PM](https://user-images.githubusercontent.com/18353636/58721350-c2f09c80-83a2-11e9-9582-e081d3bf1bf8.png)

After:
![Screen Shot 2019-05-31 at 12 49 59 PM](https://user-images.githubusercontent.com/18353636/58721351-c2f09c80-83a2-11e9-8d38-05d86d50ceea.png)

```
<ul class="guide-sidebar-below-toc-widget-area">
	<?php dynamic_sidebar( 'guide-sidebar-below-toc' ); ?>
</ul>
``` 
will have to be added to the newly merged `articles.php` template as well.