### PR TITLE
Suggestion form styles and functionality changes

### DIFF
--- a/wp-content/themes/cjet/articles.php
+++ b/wp-content/themes/cjet/articles.php
@@ -35,7 +35,7 @@ $top_page = FALSE;
 			) );
 			?>
 
-			<nav class="guide-nav span3 navbar">
+			<nav class="guide-nav span3">
 				<!-- .btn-navbar is used as the toggle for collapsed navbar content -->
 				<div class="container clearfix">
 		      <a class="btn btn-navbar toggle-nav-bar" title="More">

--- a/wp-content/themes/cjet/articles.php
+++ b/wp-content/themes/cjet/articles.php
@@ -38,19 +38,22 @@ $top_page = FALSE;
 			<nav class="guide-nav span3">
 				<!-- .btn-navbar is used as the toggle for collapsed navbar content -->
 				<div class="container clearfix">
-		      <a class="btn btn-navbar toggle-nav-bar" title="More">
-		        <div class="bars">
-			        <span class="icon-bar"></span>
-			        <span class="icon-bar"></span>
-			        <span class="icon-bar"></span>
-		        </div>
-		      </a>
+					<a class="btn btn-navbar toggle-nav-bar" title="More">
+						<div class="bars">
+							<span class="icon-bar"></span>
+							<span class="icon-bar"></span>
+							<span class="icon-bar"></span>
+						</div>
+					</a>
 
 					<?php if ( $top_page ) { ?>
-						<h4><?php _e('In This ' . ucfirst( rtrim($article_type, 's') ), 'cjet'); ?></h4>
+						<h4 class="guide-top">
+							<?php esc_html_e( 'In This ' . ucfirst( rtrim( $article_type, 's') ), 'cjet' ); ?>
+						</h4>
 					<?php } else { ?>
 						<h4 class="guide-top"><a href="<?php echo get_permalink($article_parent_id); ?>"><?php echo get_the_title($article_parent_id); ?></a></h4>
 					<?php } ?>
+
 					<ul class="guide-tree">
 						<?php echo $children; ?>
 					</ul>

--- a/wp-content/themes/cjet/css/style.css
+++ b/wp-content/themes/cjet/css/style.css
@@ -379,7 +379,7 @@ a.btn.btn.search-submit,
 }
 .guide-nav .widgettitle a,
 .guide-nav .guide-top a {
-  color: #555555;
+  color: #0089bb;
 }
 .guide-nav .widget {
   margin-top: 2em;

--- a/wp-content/themes/cjet/css/style.css
+++ b/wp-content/themes/cjet/css/style.css
@@ -1,22 +1,37 @@
 body,
+input,
+button,
+select,
+textarea,
+h5 {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  color: #1c1c1c;
+}
+.entry-content h2 {
+  color: #005270;
+  font-size: 2.75em;
+  font-weight: 700;
+}
+.entry-content h3 {
+  color: #1c1c1c;
+  font-size: 2.2em;
+  font-weight: 400;
+}
+.entry-content h4 {
+  font-size: 1.25em;
+  font-weight: 700;
+}
 .btn-primary,
 .btn,
+.give-btn,
 .navbar,
 h1,
 h2,
 h3,
 h4,
-h5,
-.widgettitle,
-input,
-button,
-select,
-textarea {
-  font-family: "effra", helvetica, sans-serif;
-  color: #555555;
-}
-h1 {
-  color: #333333;
+.widgettitle {
+  font-family: "Montserrat", "Raleway", helvetica, sans-serif;
+  color: #005270;
 }
 textarea,
 input[type="text"],
@@ -29,7 +44,7 @@ input[type="search"] {
 .entry-content p,
 .entry-content ul,
 .entry-content ol {
-  font-family: "leitura-news", georgia, serif;
+  font-family: "Merriweather", georgia, serif;
   font-weight: 300;
 }
 h1,
@@ -38,40 +53,54 @@ h3,
 h4,
 h5,
 .widgettitle {
-  font-weight: 500;
+  font-weight: 700;
 }
 a {
-  color: #09c9ff;
+  color: #0089bb;
 }
 a:hover {
-  color: #3cd4ff;
+  color: #08bdff;
 }
-.btn {
+.btn,
+a.btn,
+.give-btn {
   text-shadow: none;
   border: none;
   text-transform: uppercase;
   font-weight: bold;
   padding: 12px 24px;
-  background-color: #09c9ff;
+  background-color: #0089bb;
   color: #fff;
   border-radius: 0;
 }
-.btn:hover {
-  background-color: #00b5e8;
+.btn:hover,
+a.btn:hover,
+.give-btn:hover {
+  background-color: #00719b;
   color: #fff;
 }
-.btn.btn-primary {
+.btn.btn-primary,
+a.btn.btn-primary,
+.give-btn.btn-primary {
   color: #fff;
-  background-color: #f77710;
+  background-color: #ff8b4d;
 }
-.btn.btn-primary:hover {
-  background-color: #df6807;
+.btn.btn-primary:hover,
+a.btn.btn-primary:hover,
+.give-btn.btn-primary:hover {
+  background-color: #ff762d;
 }
-.btn.btn.search-submit {
+.btn.btn.search-submit,
+a.btn.btn.search-submit,
+.give-btn.btn.search-submit {
   padding: 4px 10px;
 }
 .donate-btn a:hover {
   color: #fff;
+}
+.navbar.sticky-navbar .nav-right #header-extras .donate a span {
+  background-color: #ff8b4d;
+  font-weight: 700;
 }
 #top-nav li {
   padding-top: 2px;
@@ -82,7 +111,7 @@ a:hover {
   font-weight: bold;
 }
 #top-nav li.main_site_home_link a {
-  color: #09c9ff;
+  color: #0089bb;
 }
 .dropdown-menu .main_site_home_link {
   display: none;
@@ -115,7 +144,7 @@ a:hover {
   color: #aaaaaa;
 }
 #site-footer a:hover {
-  color: #09c9ff;
+  color: #ffffff;
 }
 #site-footer .widgettitle,
 #site-footer li.menu-label {
@@ -137,18 +166,14 @@ a:hover {
   display: inline-block;
 }
 #site-footer #footer-social li i {
-  color: #fff;
+  color: #ffffff;
   background-color: #909799;
   padding: 14px;
   border-radius: 30px;
   margin: 0 4px;
 }
 #site-footer #footer-social li i:hover {
-  background-color: #fff;
-  color: #909799;
-}
-#site-footer #footer-social li i.icon-github:hover {
-  color: #909799;
+  background-color: #0089bb;
 }
 @media (max-width: 768px) {
   #site-footer #footer-social {
@@ -177,7 +202,7 @@ a:hover {
 }
 #menu-footer-navigation,
 #supplementary ul.menu {
-  font-family: "effra", helvetica, sans-serif;
+  font-family: "Montserrat", "Raleway", helvetica, sans-serif;
 }
 #supplementary {
   border-bottom: none;
@@ -253,10 +278,10 @@ a:hover {
   margin-bottom: 0.5em;
 }
 .stories h2.entry-title a {
-  color: #555555;
+  color: #1c1c1c;
 }
 .stories h2.entry-title a:hover {
-  color: #09c9ff;
+  color: #0089bb;
 }
 .stories h5.byline {
   display: none;
@@ -264,7 +289,7 @@ a:hover {
 .type-pull-quote {
   border-left: 1px solid #aaaaaa;
   padding-left: 40px;
-  color: #555555;
+  color: #1c1c1c;
 }
 @media (max-width: 768px) {
   .type-pull-quote {
@@ -277,33 +302,9 @@ a:hover {
     max-width: 90%;
   }
 }
-#breadcrumbs {
-  font-family: "effra", helvetica, sans-serif;
-  font-weight: 700;
-}
-#site-header,
-.home #site-header {
-  min-height: 0;
-}
-#main {
-  margin-top: 8px;
-}
-#content {
-  margin-left: 0;
-}
-#breadcrumbs {
-  margin-bottom: 24px;
-}
-#branding img {
-  margin: 24px auto 18px;
-  display: block;
-  max-width: 400px;
-  padding: 0 5%;
-  width: 90%;
-}
-body.normal.page #content.guide-page {
-  margin-left: 0;
-}
+/**
+ * Styles pertaining to guide.php and article.php
+ */
 .guide-page .author-posts-link {
   display: none;
 }
@@ -319,57 +320,19 @@ body.normal.page #content.guide-page {
   margin-bottom: 0;
   font-size: 21px;
 }
-.guide-page .toggle-nav-bar {
-  display: none;
-}
-.guide-page .guide-nav {
-  padding: 20px;
-  background-color: transparent;
-  border-right: 3px solid #ff8b4d;
-  padding-top: 0;
-}
-.guide-page .guide-nav h4 {
-  font-size: 18px;
-  text-transform: uppercase;
-  color: #0089bb;
-  margin-bottom: 15px;
-}
-.guide-page .guide-nav h4 a {
-  color: #555555;
-}
-.guide-page .guide-nav .current_page_item {
-  font-weight: bold;
-}
-.guide-page .guide-nav .current_page_item .children {
-  font-weight: normal;
-}
-.guide-page .guide-nav .guide-sidebar-below-toc-widget-area {
-  list-style: none;
-}
-.guide-page .guide-nav .guide-sidebar-below-toc-widget-area h2.widgettitle {
-  color: #1c1c1c;
-}
-@media (max-width: 768px) {
-  .guide-page .guide-nav .guide-sidebar-below-toc-widget-area {
-    display: none;
+@media (max-width: 769px) {
+  .guide-page .pager .next,
+  .guide-page .pager .previous {
+    width: 100%;
+    margin-bottom: 8px;
   }
 }
-.guide-page .guide-nav ul {
-  margin-left: 0;
+.guide-page .toggle-nav-bar {
+  margin-top: 0;
+  display: none;
 }
-.guide-page .guide-nav ul.guide-tree {
-  list-style: none;
-}
-.guide-page .guide-nav ul.guide-tree li a {
-  color: #1c1c1c;
-}
-.guide-page .guide-nav ul .largo-donate h2 {
-  font-size: 17px;
-}
-.guide-page .guide-nav ul .largo-donate p {
-  margin-bottom: 26px;
-  font-size: 16px;
-  max-width: 95%;
+.guide-page .icon-bar {
+  background-color: #1c1c1c;
 }
 .guide-page .guide-author {
   font-size: 18px;
@@ -397,41 +360,137 @@ body.normal.page #content.guide-page {
 .guide-page .author-box .author-posts-link {
   display: none;
 }
-@media screen and (max-width: 782px) {
-  .guide-page .guide-nav {
+.guide-nav {
+  background-color: transparent;
+  border-right: 3px solid #ff8b4d;
+  padding-right: 18px;
+  font-size: 15px;
+  padding-top: 0;
+}
+.guide-nav .widget p {
+  font-size: 15px;
+}
+.guide-nav .widgettitle,
+.guide-nav .guide-top {
+  font-size: 18px;
+  text-transform: uppercase;
+  color: #0089bb;
+  margin-bottom: 15px;
+}
+.guide-nav .widgettitle a,
+.guide-nav .guide-top a {
+  color: #555555;
+}
+.guide-nav .widget {
+  margin-top: 2em;
+}
+.guide-nav .widget:last-child {
+  margin-bottom: 0;
+}
+.guide-nav .current_page_item > a::before {
+  color: #0089bb;
+  width: 1em;
+  display: block;
+  float: left;
+  text-align: center;
+  margin-left: -1em;
+  content: '\00BB';
+}
+.guide-nav .guide-tree {
+  list-style: none;
+  margin-left: 0;
+  margin-top: 0;
+}
+.guide-nav .guide-tree ul.children {
+  margin-top: 0;
+  margin-left: 2em;
+  list-style-type: disc;
+  list-style-type: '-';
+}
+.guide-nav .guide-tree ul.children li {
+  margin-bottom: 0;
+}
+.guide-nav .guide-tree a {
+  color: #1c1c1c;
+}
+.guide-nav .guide-tree a:hover {
+  color: #1c1c1c;
+  text-decoration: underline;
+}
+.guide-nav .guide-tree .largo-donate h2 {
+  font-size: 17px;
+}
+.guide-nav .guide-tree .largo-donate p {
+  margin-bottom: 26px;
+  font-size: 16px;
+  max-width: 95%;
+}
+.guide-nav .guide-sidebar-below-toc-widget-area {
+  list-style: none;
+}
+@media (max-width: 769px) {
+  .guide-nav .guide-sidebar-below-toc-widget-area {
+    display: none;
+  }
+}
+@media (max-width: 769px) {
+  .guide-nav {
+    border-left: 3px solid #ff8b4d;
+    border-right: none;
+  }
+  .guide-nav.span3 {
     width: 100%;
     padding: 0;
   }
-  .guide-page .guide-nav .container {
-    margin: 5px 10px;
-  }
-  .guide-page .guide-nav .guide-tree,
-  .guide-page .guide-nav .resources {
+  .guide-nav .guide-tree,
+  .guide-nav .resources {
     display: none;
   }
-  .guide-page .guide-nav .toggle-nav-bar {
+  .guide-nav.open .guide-tree,
+  .guide-nav.open .resources {
     display: block;
-    margin-top: 0;
   }
-  .guide-page .guide-nav h4 {
-    font-size: 21px;
-    margin: 0.1em 0;
-    color: black;
+  .guide-nav .guide-top {
+    margin-bottom: 0;
   }
-  .guide-page .guide-nav ul {
-    margin: 0 -10px 0 44px;
+  .guide-nav .guide-tree {
+    padding-left: 10px;
+    margin-bottom: 0;
   }
-  .guide-page .guide-nav li {
+  .guide-nav .toggle-nav-bar,
+  .guide-nav .guide-top {
+    line-height: 56px;
+    display: inline-block;
+  }
+  .guide-nav .toggle-nav-bar {
+    background-color: transparent;
+    color: #ffffff;
+    padding: 0 10px;
+  }
+  .guide-nav .toggle-nav-bar:hover {
+    background-color: transparent;
+    color: white;
+  }
+  .guide-nav .toggle-nav-bar .bars {
+    display: inline-block;
+  }
+  .guide-nav .toggle-nav-bar .icon-bar {
+    display: block;
+    width: 18px;
+    height: 3px;
+  }
+  .guide-nav .toggle-nav-bar .icon-bar + .icon-bar {
+    margin-top: 3px;
+  }
+  .guide-nav li {
     display: block;
     float: none;
   }
-  .guide-page .guide-nav li > a {
-    color: #0089bb;
-    padding: 6px 10px;
-  }
-  .guide-page .guide-nav .resources h4 {
+  .guide-nav .resources h4 {
     margin-left: 46px;
   }
+}
+@media (max-width: 769px) {
   .guide-page article.span9 {
     width: 100%;
     margin-left: 0;
@@ -443,11 +502,6 @@ body.normal.page #content.guide-page {
   }
   .guide-page article.span9 .entry-content h3.guide-author {
     margin-bottom: 0;
-  }
-  .guide-page .pager .next,
-  .guide-page .pager .previous {
-    width: 100%;
-    margin-bottom: 8px;
   }
 }
 .guide-resources {
@@ -484,8 +538,69 @@ body.normal.page #content.guide-page {
 .guide-resources .icon-download {
   color: indigo;
 }
-@media screen and (max-width: 768px) {
+details.guide-form {
+  border: 1px solid transparent;
+}
+details.guide-form summary {
+  width: 100%;
+  box-sizing: border-box;
+}
+details.guide-form summary::before,
+details.guide-form summary::-webkit-details-marker {
+  display: none;
+}
+details.guide-form[open] {
+  border-color: #1c1c1c;
+}
+details.guide-form[open] summary:active,
+details.guide-form[open] summary:hover,
+details.guide-form[open] summary {
+  background-color: #ffffff;
+  color: #1c1c1c;
+}
+details.guide-form[open] summary:active::after,
+details.guide-form[open] summary:hover::after,
+details.guide-form[open] summary::after {
+  display: inline;
+  content: ":";
+}
+details.guide-form[open] .gform_wrapper {
+  color: #1c1c1c;
+  padding: 0 2px;
+  margin: 0;
+}
+details.guide-form[open] .gform_wrapper ul.gform_fields li.gfield {
+  padding-right: 0;
+}
+#breadcrumbs {
+  font-family: "Montserrat", "Raleway", helvetica, sans-serif;
+  font-weight: 700;
+  margin-bottom: 24px;
+}
+@media (max-width: 769px) {
   #breadcrumbs {
     display: none;
   }
+}
+#site-header,
+.home #site-header {
+  min-height: 0;
+}
+@media screen and (max-width: 769px) {
+  #main {
+    margin-top: 56px;
+  }
+}
+#content {
+  margin-left: 0;
+}
+#branding img {
+  margin: 24px auto 18px;
+  display: block;
+  max-width: 400px;
+  padding: 0 5%;
+  width: 90%;
+}
+body.normal.page #content.guide-page {
+  margin-left: 0;
 }

--- a/wp-content/themes/cjet/functions.php
+++ b/wp-content/themes/cjet/functions.php
@@ -16,7 +16,7 @@ foreach ( $includes as $include ) {
 }
 
 
-// Custom scripts
+// Custom script
 function cjet_enqueue() {
 	wp_enqueue_script( 'cjet-javascript', get_stylesheet_directory_uri() . '/js/cjet.js' );
 }
@@ -41,15 +41,6 @@ function cjet_breadcrumbs() {
 }
 add_action( 'largo_main_top', 'cjet_breadcrumbs' );
 
-
-if( FALSE === get_option("large_crop") ) {
-	add_option("large_crop", "1");
-	add_option("medium_crop", "1");
-} else {
-	update_option("large_crop", "1");
-	update_option("medium_crop", "1");
-}
-
 add_theme_support( 'custom-header' );
 
 
@@ -58,7 +49,6 @@ function cjet_init() {
 	add_post_type_support( 'page', 'excerpt' );
 }
 add_action( 'init', 'cjet_init' );
-
 
 // Add extra theme options
 function cjet_theme_options( $options ) {
@@ -82,3 +72,12 @@ function cjet_theme_options( $options ) {
 	return $options;
 }
 add_filter('largo_options', 'cjet_theme_options');
+
+/**
+ * Enable shortcodes in Custom HTML Widget
+ *
+ * @link https://github.com/INN/umbrella-inndev/issues/68#issuecomment-497853084
+ * @link https://core.trac.wordpress.org/browser/tags/5.2/src/wp-includes/widgets/class-wp-widget-custom-html.php#L158
+ */
+add_filter( 'widget_custom_html_content', 'shortcode_unautop');
+add_filter( 'widget_custom_html_content', 'do_shortcode');

--- a/wp-content/themes/cjet/guides.php
+++ b/wp-content/themes/cjet/guides.php
@@ -51,7 +51,9 @@ $top_page = FALSE;
 					</a>
 
 					<?php if ( $top_page ) { ?>
-						<h4><?php esc_html_e('In This ' . ucfirst( rtrim($guide_type, 's') ), 'cjet'); ?></h4>
+						<h4 class="guide-top">
+							<?php esc_html_e( 'In This ' . ucfirst( rtrim( $guide_type, 's') ), 'cjet' ); ?>
+						</h4>
 					<?php } else { ?>
 						<h4 class="guide-top">
 							<a href="<?php echo esc_attr( get_permalink( $guide_parent_id ) ); ?>">

--- a/wp-content/themes/cjet/guides.php
+++ b/wp-content/themes/cjet/guides.php
@@ -27,39 +27,48 @@ $top_page = FALSE;
 
 			// now get the complete tree of child pages for the guide's top page
 			$children = wp_list_pages('title_li=&child_of=' . $guide_parent_id . '&echo=0');
+
+			/*
+			 * Commented out until we're sure of what we want to do with attachments
 			$attachments = get_posts( array(
 				'post_type' => 'attachment',
 				'posts_per_page' => -1,
 				'post_parent' => $guide_parent_id,
 				'exclude'     => get_post_thumbnail_id( $guide_parent_id ), //don't get the featured image
 			) );
+			*/
 			?>
 
 			<nav class="guide-nav span3 navbar">
 				<!-- .btn-navbar is used as the toggle for collapsed navbar content -->
 				<div class="container clearfix">
-		      <a class="btn btn-navbar toggle-nav-bar" title="More">
-		        <div class="bars">
-			        <span class="icon-bar"></span>
-			        <span class="icon-bar"></span>
-			        <span class="icon-bar"></span>
-		        </div>
-		      </a>
-					
+					<a class="btn btn-navbar toggle-nav-bar" title="More">
+						<div class="bars">
+							<span class="icon-bar"></span>
+							<span class="icon-bar"></span>
+							<span class="icon-bar"></span>
+						</div>
+					</a>
+
 					<?php if ( $top_page ) { ?>
-						<h4><?php _e('In This ' . ucfirst( rtrim($guide_type, 's') ), 'cjet'); ?></h4>
+						<h4><?php esc_html_e('In This ' . ucfirst( rtrim($guide_type, 's') ), 'cjet'); ?></h4>
 					<?php } else { ?>
-						<h4 class="guide-top"><a href="<?php echo get_permalink($guide_parent_id); ?>"><?php echo get_the_title($guide_parent_id); ?></a></h4>
+						<h4 class="guide-top">
+							<a href="<?php echo esc_attr( get_permalink( $guide_parent_id ) ); ?>">
+								<?php echo get_the_title( $guide_parent_id ); ?>
+							</a>
+						</h4>
 					<?php } ?>
+
 					<ul class="guide-tree">
 						<?php echo $children; ?>
-					</ul>
-					
-					<ul class="guide-sidebar-below-toc-widget-area">
+
 						<?php dynamic_sidebar( 'guide-sidebar-below-toc' ); ?>
 					</ul>
 
 					<?php
+					/*
+					 * Commented out until we're sure of what we want to do with attachments
 					// on interior guide pages, list resources attached to the parent guide page
 					// if ( $attachments ) : ?>
 					<!-- <div class="resources">
@@ -76,8 +85,9 @@ $top_page = FALSE;
 						<!-- </ul></div> -->
 							<?php
 					// endif;	// resources links
-					?>
 
+					*/
+					?>
 				</div>
 			</nav>
 

--- a/wp-content/themes/cjet/guides.php
+++ b/wp-content/themes/cjet/guides.php
@@ -39,7 +39,7 @@ $top_page = FALSE;
 			*/
 			?>
 
-			<nav class="guide-nav span3 navbar">
+			<nav class="guide-nav span3">
 				<!-- .btn-navbar is used as the toggle for collapsed navbar content -->
 				<div class="container clearfix">
 					<a class="btn btn-navbar toggle-nav-bar" title="More">

--- a/wp-content/themes/cjet/inc/sidebars.php
+++ b/wp-content/themes/cjet/inc/sidebars.php
@@ -14,6 +14,8 @@ function cjet_register_sidebars() {
 		'name'			=> __( 'Guide Sidebar Below Table of Contents', 'cjet' ),
 		'id' 			=> 'guide-sidebar-below-toc',
 		'description' 	=> __( 'Widget area for Guides sidebar. This will appear below the table of contents.', 'cjet' ),
+		'before_title' 	=> '<h3 class="widgettitle">',
+		'after_title' 	=> '</h3>',
 	) );
 }
 add_action( 'widgets_init', 'cjet_register_sidebars' );

--- a/wp-content/themes/cjet/js/cjet.js
+++ b/wp-content/themes/cjet/js/cjet.js
@@ -1,17 +1,13 @@
 jQuery(document).ready( function($) {
-
 	$(".guide-nav a.btn").on('click', function() {
-		$('.guide-nav .guide-tree, .guide-nav .resources').toggle();
+		$('.guide-nav').toggleClass('open');
 	});
 
 	$(window).on('resize', function() {
-		if ( $(window).width() < 768 ) {
-			$('.guide-nav').addClass('navbar');
-		} else {
-			$('.guide-nav').removeClass('navbar open');
+		if ( ! $(window).width() < 768 ) {
+			$('.guide-nav').removeClass('open');
 		}
 	});
 
 	$(window).trigger('resize');
-
 });

--- a/wp-content/themes/cjet/js/cjet.js
+++ b/wp-content/themes/cjet/js/cjet.js
@@ -7,10 +7,8 @@ jQuery(document).ready( function($) {
 	$(window).on('resize', function() {
 		if ( $(window).width() < 768 ) {
 			$('.guide-nav').addClass('navbar');
-			$('.guide-nav .guide-tree, .guide-nav .resources').hide();
 		} else {
-			$('.guide-nav').removeClass('navbar');
-			$('.guide-nav .guide-tree, .guide-nav .resources').show();
+			$('.guide-nav').removeClass('navbar open');
 		}
 	});
 

--- a/wp-content/themes/cjet/less/guides.less
+++ b/wp-content/themes/cjet/less/guides.less
@@ -1,0 +1,296 @@
+/**
+ * Styles pertaining to guide.php and article.php
+ */
+
+.guide-page {
+  .author-posts-link {
+    display: none;
+  }
+  .entry-content .widget {
+    padding: 15px 0;
+  }
+  .pager {
+    a {
+      width: 100%;
+      box-sizing: border-box;
+      height: 100%;
+    }
+    h5.top-page {
+      margin-bottom: 0;
+      font-size: 21px;
+    }
+    @media (max-width:@breakpoint) {
+      .next,
+      .previous {
+        width: 100%;
+        margin-bottom: 8px;
+      }
+    }
+  }
+  .toggle-nav-bar {
+    margin-top: 0;
+    display: none;
+
+  }
+  .icon-bar {
+    background-color: @black;
+  }
+  .guide-author {
+    font-size: 18px;
+    text-transform: uppercase;
+    margin-bottom: 8px;
+    color: @medgray;
+  }
+  .author-box {
+    a {
+      color: @medgray;
+    }
+    h3 {
+      font-size: 18px;
+      margin-bottom: 8px;
+      a {
+        color: #000;
+      }
+    }
+    h5 {
+      margin-bottom: 8px;
+    }
+    ul {
+      padding: 0;
+      margin: 0;
+    }
+    .author-posts-link {
+      display: none;
+    }
+  }
+}
+.guide-nav {
+  background-color: transparent;
+  border-right: 3px solid @orange;
+  padding-right: 18px; // to match the padding on #page;
+
+  @fontsize: 15px;
+  font-size: @fontsize;
+  .widget p {
+    font-size: @fontsize;
+  }
+
+  padding-top: 0;
+  .widgettitle,
+  .guide-top {
+    font-size: 18px;
+    text-transform: uppercase;
+    color: @blue;
+    margin-bottom:15px;
+    a {
+      color: @dkgray;
+    }
+  }
+  .widget {
+    margin-top: 2em;
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+  .current_page_item {
+    &>a::before {
+      color: @blue;
+      width: 1em;
+      display: block;
+      float: left;
+      text-align: center;
+      margin-left: -1em;
+      content: '\00BB';
+    }
+  }
+  .guide-tree {
+    list-style: none;
+    margin-left: 0;
+    margin-top: 0;
+    ul.children {
+      margin-top: 0;
+      margin-left: 2em;
+      list-style-type: disc;
+      list-style-type: '-';
+      li {
+        margin-bottom: 0;
+      }
+    }
+    a {
+      color: @black;
+      &:hover {
+        color: @black;
+        text-decoration: underline;
+      }
+    }
+
+    .largo-donate{
+      h2 {
+        font-size: 17px;
+      }
+      p {
+        margin-bottom: 26px;
+        font-size: 16px;
+        max-width: 95%;
+      }
+    }
+  }
+  .guide-sidebar-below-toc-widget-area {
+    list-style: none;
+    @media (max-width: @breakpoint) {
+      display: none;
+    }
+  }
+  @media (max-width:@breakpoint) {
+    border-left: 3px solid @orange;
+    border-right: none;
+
+    // a bunch of display logic
+    &.span3 {
+      width: 100%;
+      padding: 0;
+    }
+    .guide-tree,
+    .resources {
+      display: none;
+    }
+    &.open {
+      .guide-tree,
+      .resources {
+        display: block;
+      }
+    }
+    .guide-top {
+      margin-bottom: 0;
+    }
+    .guide-tree {
+      padding-left: 10px; // to match whitespace on the nav toggle;
+      margin-bottom: 0;
+    }
+
+    // as regards the nav button
+    .toggle-nav-bar, .guide-top {
+      line-height: @stickyNavLineHeight;
+      display: inline-block;
+    }
+    .toggle-nav-bar {
+      background-color: transparent;
+      color: @white;
+      padding: 0 10px;
+
+      &:hover {
+        background-color: transparent;
+        color: white;
+      }
+
+      // then we recreate all the styles that apply to .navbar .toggle-nav-bar
+      // we do this because using .navbar on a parent element prevents scrolling when this menu is open on mobile,
+      // and that prevents people from seeing the whole menu.
+      .bars {
+        display: inline-block;
+      }
+      .icon-bar {
+        display: block;
+        width: 18px;
+        height: 3px;
+        & + .icon-bar {
+          margin-top: 3px;
+        }
+      }
+    }
+
+
+    li {
+      display: block;
+      float: none;
+    }
+    .resources h4 {
+      margin-left: 46px;
+    }
+  }
+}
+@media (max-width:@breakpoint) {
+  .guide-page article.span9 {
+    width: 100%;
+    margin-left: 0;
+    margin-top: 10px;
+    .entry-content h3 {
+      font-size: 21px;
+      margin-bottom: 12px;
+      &.guide-author {
+        margin-bottom: 0;
+      }
+    }
+  }
+}
+.guide-resources {
+  margin-left: 0;
+  li {
+    display: block;
+  }
+  a {
+    word-wrap: break-word;
+    word-break: break-word;
+  }
+  .attachment-meta {
+    white-space: nowrap;
+  }
+  i {
+    -webkit-font-smoothing: antialiased;
+  }
+  .icon-picture {
+    color: cadetblue;
+  }
+  .icon-play {
+    color: crimson;
+  }
+  .icon-table {
+    color: forestgreen;
+  }
+  .icon-doc-text {
+    color: mediumblue;
+  }
+  .icon-doc-text-inv {
+    color: firebrick;
+  }
+  .icon-download {
+    color: indigo;
+  }
+}
+details.guide-form{
+  border: 1px solid transparent;
+  summary{
+    width: 100%;
+    box-sizing: border-box;
+
+    &::before,
+    &::-webkit-details-marker {
+      display: none;
+    }
+  }
+  &[open] {
+    border-color: @black;
+
+    summary:active,
+    summary:hover,
+    summary {
+      background-color: @white;
+      color: @black;
+      &::after {
+        display: inline;
+        content: ":";
+      }
+    }
+
+    .gform_wrapper {
+      color: @black;
+      padding: 0 2px;
+      margin: 0;
+
+      ul.gform_fields li.gfield {
+        padding-right: 0;
+      }
+    }
+  }
+}
+

--- a/wp-content/themes/cjet/less/guides.less
+++ b/wp-content/themes/cjet/less/guides.less
@@ -83,7 +83,7 @@
     color: @blue;
     margin-bottom:15px;
     a {
-      color: @dkgray;
+      color: @blue;
     }
   }
   .widget {

--- a/wp-content/themes/cjet/less/style.less
+++ b/wp-content/themes/cjet/less/style.less
@@ -1,22 +1,35 @@
+// branding imports from INN
 @import "../../inn/less/variables.less";
 @import "../../inn/less/common.less";
+
+@breakpoint: 769px;
+@stickyNavLineHeight: 56px;
+
+
+// local styles
+@import "guides.less";
 
 #breadcrumbs  {
   font-family: @sans;
   font-weight: 700;
+  margin-bottom: 24px;
+  @media (max-width: @breakpoint) {
+    display: none;
+  }
 }
+
 #site-header,
 .home #site-header {
   min-height: 0;
 }
+
 #main {
-  margin-top: 8px;
+  @media screen and (max-width:@breakpoint) {
+    margin-top: @stickyNavLineHeight;
+  }
 }
 #content {
   margin-left: 0;
-}
-#breadcrumbs {
-  margin-bottom: 24px;
 }
 #branding img {
   margin: 24px auto 18px;
@@ -27,218 +40,4 @@
 }
 body.normal.page #content.guide-page {
   margin-left: 0;
-}
-.guide-page {
-  .author-posts-link {
-    display: none;
-  }
-  .entry-content .widget {
-    padding: 15px 0;
-  }
-  .pager {
-    a {
-      width: 100%;
-      box-sizing: border-box;
-      height: 100%;
-    }
-    h5.top-page {
-	  margin-bottom: 0;
-	  font-size: 21px;
-    }
-  }
-  .toggle-nav-bar {
-    display: none;
-  }
-  .guide-nav {
-    padding: 20px;
-    background-color: transparent;
-    border-right: 3px solid @orange;
-    padding-top: 0;
-    h4 {
-      font-size: 18px;
-      text-transform: uppercase;
-      color: #0089bb;
-      margin-bottom:15px;
-      a {
-        color: @dkgray;
-      }
-    }
-    .current_page_item {
-      font-weight: bold;
-      .children {
-        font-weight: normal;
-      }
-    }
-    .guide-sidebar-below-toc-widget-area {
-      list-style: none;
-      h2 {
-        &.widgettitle {
-        color: #1c1c1c;
-        }
-      }
-      @media (max-width: 768px) {
-        display: none;
-      }
-    }
-    ul {
-      margin-left: 0;
-      &.guide-tree {
-        list-style: none;
-        li {
-          a {
-            color: #1c1c1c;
-          }
-        }
-      }
-      .largo-donate{
-        h2 {
-          font-size: 17px;
-        }
-        p {
-          margin-bottom: 26px;
-          font-size: 16px;
-          max-width: 95%;
-        }
-      }
-    }
-  }
-  .guide-author {
-    font-size: 18px;
-    text-transform: uppercase;
-    margin-bottom: 8px;
-    color: @medgray;
-  }
-  .author-box {
-    a {
-	  color: @medgray;
-    }
-    h3 {
-	  font-size: 18px;
-	  margin-bottom: 8px;
-	  a {
-        color: #000;
-	  }
-	}
-    h5 {
-      margin-bottom: 8px;
-    }
-    ul {
-	  padding: 0;
-	  margin: 0;
-    }
-    .author-posts-link {
-      display: none;
-    }
-  }
-  @media screen and (max-width:782px) {
-    .guide-nav {
-      width: 100%;
-      padding: 0;
-      .container {
-        margin: 5px 10px;
-      }
-      .guide-tree,
-      .resources {
-        display: none;
-      }
-      .toggle-nav-bar {
-        display: block;
-        margin-top: 0
-      }
-      h4 {
-        font-size: 21px;
-        margin: 0.1em 0;
-        color: black;
-      }
-      ul {
-        margin: 0 -10px 0 44px
-      }
-      li {
-        display: block;
-        float: none;
-        > a {
-          color: @blue;
-          padding: 6px 10px;
-        }
-      }
-      .resources h4 {
-        margin-left: 46px;
-      }
-    }
-    article.span9 {
-      width: 100%;
-      margin-left: 0;
-      margin-top: 10px;
-      .entry-content h3 {
-	    font-size: 21px;
-	    margin-bottom: 12px;
-	    &.guide-author {
-		  margin-bottom: 0;
-	    }
-      }
-    }
-    .pager .next,
-    .pager .previous {
-	  width: 100%;
-	  margin-bottom: 8px;
-    }
-  }
-}
-.guide-resources {
-  margin-left: 0;
-  li {
-    display: block;
-  }
-  a {
-    word-wrap: break-word;
-    word-break: break-word;
-  }
-  .attachment-meta {
-    white-space: nowrap;
-  }
-  i {
-    -webkit-font-smoothing: antialiased;
-  }
-  .icon-picture {
-    color: cadetblue;
-  }
-  .icon-play {
-    color: crimson;
-  }
-  .icon-table {
-    color: forestgreen;
-  }
-  .icon-doc-text {
-    color: mediumblue;
-  }
-  .icon-doc-text-inv {
-    color: firebrick;
-  }
-  .icon-download {
-    color: indigo;
-  }
-}
-details.guide-form{
-  border: 1px solid transparent;
-  summary{
-    width: 100%;
-    box-sizing: border-box;
-
-    &::before,
-    &::-webkit-details-marker {
-      display: none;
-    }
-  }
-  &[open] {
-    border-color: @black;
-    summary {
-      background-color: @white;
-      color: @black;
-    }
-  }
-}
-@media screen and (max-width: 768px) {
-  #breadcrumbs {
-    display: none;
-  }
 }

--- a/wp-content/themes/cjet/less/style.less
+++ b/wp-content/themes/cjet/less/style.less
@@ -212,10 +212,29 @@ body.normal.page #content.guide-page {
     color: mediumblue;
   }
   .icon-doc-text-inv {
-	color: firebrick;
+    color: firebrick;
   }
   .icon-download {
     color: indigo;
+  }
+}
+details.guide-form{
+  border: 1px solid transparent;
+  summary{
+    width: 100%;
+    box-sizing: border-box;
+
+    &::before,
+    &::-webkit-details-marker {
+      display: none;
+    }
+  }
+  &[open] {
+    border-color: @black;
+    summary {
+      background-color: @white;
+      color: @black;
+    }
   }
 }
 @media screen and (max-width: 768px) {


### PR DESCRIPTION
## Changes

- restyles sidebar to match [guide styles v6.png](https://drive.google.com/open?id=1sZtez483RUtpepH85uj-QF7Zek0tytkG), for https://github.com/INN/umbrella-inndev/issues/68 and https://github.com/INN/umbrella-inndev/issues/76
- unifies breakpoint for when the guide nav collapses to its mobile appearance, to fix the Learn theme's version of https://github.com/INN/inn/issues/104
- rewrites most of the mobile styles for the guide nav so that they work, and better match the non-mobile styles
- enables shortcodes in the Custom HTML widget
- provides styles for a widget that matches this:
	```html
	<p>
		We welcome additions and suggestions to keep our guides up to date for INN members. Please send us your suggested resources, sample policies, case studies or article suggestions.
	</p>

	<details class="guide-form">
	<summary class="btn btn-primary">submit feedback</summary>
	[gravityform id="1" title="false" description="false"]
	</details>
	```
- removes no-longer-necessary forcing of option "large_crop": it's been set once, it doesn't need to [be set on every page load](https://wp-snippet.com/snippets/activate-cropping-for-all-thumbnail-sizes/)
- maintains parity between article.php and guide.php

## Screenshots

New sidebar styles:
![Screen Shot 2019-05-31 at 21 59 09 ](https://user-images.githubusercontent.com/1754187/58742120-aaf33a00-83ef-11e9-800a-e3ac023f8783.png)
![Screen Shot 2019-05-31 at 22 00 37 ](https://user-images.githubusercontent.com/1754187/58742121-ab8bd080-83ef-11e9-97ba-b502d01121e2.png)
![Screen Shot 2019-05-31 at 22 00 50 ](https://user-images.githubusercontent.com/1754187/58742122-ab8bd080-83ef-11e9-8a7f-1410f0006c6b.png)
![Screen Shot 2019-05-31 at 22 00 53 ](https://user-images.githubusercontent.com/1754187/58742123-ab8bd080-83ef-11e9-9af8-b8bb23e77e46.png)
![Screen Shot 2019-05-31 at 22 01 02 ](https://user-images.githubusercontent.com/1754187/58742124-ab8bd080-83ef-11e9-8f49-aa9c1e5f11f8.png)
![Screen Shot 2019-05-31 at 22 01 15 ](https://user-images.githubusercontent.com/1754187/58742125-ab8bd080-83ef-11e9-9d67-8fefba2f003e.png)


The contents of the open form: 

![learn inndev test_guides_fundraising_ (1)](https://user-images.githubusercontent.com/1754187/58742131-c0686400-83ef-11e9-914e-1e2cdd31d16c.png)
