### PR TITLE
Homepage guides and topics sections

### DIFF
--- a/wp-content/themes/cjet/css/style.css
+++ b/wp-content/themes/cjet/css/style.css
@@ -1,22 +1,37 @@
 body,
+input,
+button,
+select,
+textarea,
+h5 {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  color: #1c1c1c;
+}
+.entry-content h2 {
+  color: #005270;
+  font-size: 2.75em;
+  font-weight: 700;
+}
+.entry-content h3 {
+  color: #1c1c1c;
+  font-size: 2.2em;
+  font-weight: 400;
+}
+.entry-content h4 {
+  font-size: 1.25em;
+  font-weight: 700;
+}
 .btn-primary,
 .btn,
+.give-btn,
 .navbar,
 h1,
 h2,
 h3,
 h4,
-h5,
-.widgettitle,
-input,
-button,
-select,
-textarea {
-  font-family: "effra", helvetica, sans-serif;
-  color: #555555;
-}
-h1 {
-  color: #333333;
+.widgettitle {
+  font-family: "Montserrat", "Raleway", helvetica, sans-serif;
+  color: #005270;
 }
 textarea,
 input[type="text"],
@@ -29,7 +44,7 @@ input[type="search"] {
 .entry-content p,
 .entry-content ul,
 .entry-content ol {
-  font-family: "leitura-news", georgia, serif;
+  font-family: "Merriweather", georgia, serif;
   font-weight: 300;
 }
 h1,
@@ -38,40 +53,54 @@ h3,
 h4,
 h5,
 .widgettitle {
-  font-weight: 500;
+  font-weight: 700;
 }
 a {
-  color: #09c9ff;
+  color: #0089bb;
 }
 a:hover {
-  color: #3cd4ff;
+  color: #08bdff;
 }
-.btn {
+.btn,
+a.btn,
+.give-btn {
   text-shadow: none;
   border: none;
   text-transform: uppercase;
   font-weight: bold;
   padding: 12px 24px;
-  background-color: #09c9ff;
+  background-color: #0089bb;
   color: #fff;
   border-radius: 0;
 }
-.btn:hover {
-  background-color: #00b5e8;
+.btn:hover,
+a.btn:hover,
+.give-btn:hover {
+  background-color: #00719b;
   color: #fff;
 }
-.btn.btn-primary {
+.btn.btn-primary,
+a.btn.btn-primary,
+.give-btn.btn-primary {
   color: #fff;
-  background-color: #f77710;
+  background-color: #ff8b4d;
 }
-.btn.btn-primary:hover {
-  background-color: #df6807;
+.btn.btn-primary:hover,
+a.btn.btn-primary:hover,
+.give-btn.btn-primary:hover {
+  background-color: #ff762d;
 }
-.btn.btn.search-submit {
+.btn.btn.search-submit,
+a.btn.btn.search-submit,
+.give-btn.btn.search-submit {
   padding: 4px 10px;
 }
 .donate-btn a:hover {
   color: #fff;
+}
+.navbar.sticky-navbar .nav-right #header-extras .donate a span {
+  background-color: #ff8b4d;
+  font-weight: 700;
 }
 #top-nav li {
   padding-top: 2px;
@@ -82,7 +111,7 @@ a:hover {
   font-weight: bold;
 }
 #top-nav li.main_site_home_link a {
-  color: #09c9ff;
+  color: #0089bb;
 }
 .dropdown-menu .main_site_home_link {
   display: none;
@@ -115,7 +144,7 @@ a:hover {
   color: #aaaaaa;
 }
 #site-footer a:hover {
-  color: #09c9ff;
+  color: #ffffff;
 }
 #site-footer .widgettitle,
 #site-footer li.menu-label {
@@ -137,18 +166,14 @@ a:hover {
   display: inline-block;
 }
 #site-footer #footer-social li i {
-  color: #fff;
+  color: #ffffff;
   background-color: #909799;
   padding: 14px;
   border-radius: 30px;
   margin: 0 4px;
 }
 #site-footer #footer-social li i:hover {
-  background-color: #fff;
-  color: #909799;
-}
-#site-footer #footer-social li i.icon-github:hover {
-  color: #909799;
+  background-color: #0089bb;
 }
 @media (max-width: 768px) {
   #site-footer #footer-social {
@@ -177,7 +202,7 @@ a:hover {
 }
 #menu-footer-navigation,
 #supplementary ul.menu {
-  font-family: "effra", helvetica, sans-serif;
+  font-family: "Montserrat", "Raleway", helvetica, sans-serif;
 }
 #supplementary {
   border-bottom: none;
@@ -253,10 +278,10 @@ a:hover {
   margin-bottom: 0.5em;
 }
 .stories h2.entry-title a {
-  color: #555555;
+  color: #1c1c1c;
 }
 .stories h2.entry-title a:hover {
-  color: #09c9ff;
+  color: #0089bb;
 }
 .stories h5.byline {
   display: none;
@@ -264,7 +289,7 @@ a:hover {
 .type-pull-quote {
   border-left: 1px solid #aaaaaa;
   padding-left: 40px;
-  color: #555555;
+  color: #1c1c1c;
 }
 @media (max-width: 768px) {
   .type-pull-quote {
@@ -278,7 +303,7 @@ a:hover {
   }
 }
 #breadcrumbs {
-  font-family: "effra", helvetica, sans-serif;
+  font-family: "Montserrat", "Raleway", helvetica, sans-serif;
   font-weight: 700;
 }
 #site-header,
@@ -322,6 +347,7 @@ a:hover {
   justify-content: end;
   display: inherit;
   margin-bottom: 25px;
+  margin-left: 20px;
 }
 #site-header #header-search input {
   border-color: #000;

--- a/wp-content/themes/cjet/functions.php
+++ b/wp-content/themes/cjet/functions.php
@@ -68,7 +68,7 @@ function cjet_theme_options( $options ) {
 		'type' 	=> 'heading');
 
 	$options[] = array(
-		'desc' 	=> __('Enter a description of the guides to appear on the homepage.', 'cjet'),
+		'desc' 	=> __('Enter a description of the topics section that appears on the homepage.', 'cjet'),
 		'id' 	=> 'cjet_guides_intro',
 		'std' 	=> '',
 		'type' 	=> 'textarea');

--- a/wp-content/themes/cjet/functions.php
+++ b/wp-content/themes/cjet/functions.php
@@ -68,12 +68,6 @@ function cjet_theme_options( $options ) {
 		'type' 	=> 'heading');
 
 	$options[] = array(
-		'desc' 	=> __('Enter a description of the online courses to appear on the homepage.', 'cjet'),
-		'id' 	=> 'cjet_courses_intro',
-		'std' 	=> '',
-		'type' 	=> 'textarea');
-
-	$options[] = array(
 		'desc' 	=> __('Enter a description of the guides to appear on the homepage.', 'cjet'),
 		'id' 	=> 'cjet_guides_intro',
 		'std' 	=> '',

--- a/wp-content/themes/cjet/homepages/assets/css/cjet.css
+++ b/wp-content/themes/cjet/homepages/assets/css/cjet.css
@@ -1,29 +1,10 @@
-.home .stories article {
-  border-bottom: none;
-}
-.home .stories article img.attachment-medium {
-  max-width: 100%;
-}
-.home #courses,
+.home #top,
 .home #guides {
   clear: both;
+  padding: 5vw 2vw;
 }
-.home #courses > h1,
-.home #guides > h1,
-.home #courses > .description,
-.home #guides > .description {
-  text-align: center;
-}
-.home #courses ul,
-.home #guides ul {
-  margin: 0;
-  padding: 0;
-  text-align: left;
-  overflow: hidden;
-  font-size: 0;
-}
-.home #courses li,
-.home #guides li {
+.home #top .widget,
+.home #guides .widget {
   display: inline-block;
   margin-right: 0.85470085%;
   margin-left: 0.85470085%;
@@ -31,88 +12,69 @@
   vertical-align: top;
   text-align: left;
 }
-.home #courses span[data-picture],
+.home #top span[data-picture],
 .home #guides span[data-picture] {
   max-width: 100%;
   height: auto;
 }
-.home #courses br,
-.home #guides br {
-  clear: left;
-}
-.home #courses h1,
-.home #guides h1 {
-  font-size: 40px;
+.home #top h2,
+.home #guides h2 {
+  font-size: 20px;
+  font-size: calc( 10px + 2vw );
   margin-bottom: 12px;
 }
-.home #courses h4,
-.home #guides h4 {
+.home #top h2 a,
+.home #guides h2 a,
+.home #top p a,
+.home #guides p a {
+  color: #1c1c1c;
+}
+.home #top .widgettitle,
+.home #guides .widgettitle {
   font-size: 24px;
   margin-bottom: 4px;
   line-height: 1.2;
+  color: #0089bb;
+  text-transform: none;
 }
-.home #courses p,
+.home #top p,
 .home #guides p {
   font-size: 15px;
 }
-.home #extras {
-  margin-bottom: 24px;
-}
-.home #extras .widget p,
-.home #extras .widget ul,
-.home #extras .largo-recent-posts h5 {
-  padding: 0;
-}
-.home #extras .widget p {
-  font-size: 13.04px;
-  margin-bottom: 4px;
-}
-.home #extras .widget p.more-link {
-  font-weight: bold;
-}
-.home #courses li {
-  width: 31.62393162393162%;
-}
-.home #guides li {
-  width: 23.29059829%;
-}
-.home #extras {
+.home #top {
   background-color: #edf1f4;
-  padding: 10px;
-  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
-.home #extras > aside {
-  box-sizing: border-box;
-  padding: 10px;
-  width: 33.3333%;
-  float: left;
-  border-top: 0;
+.home #top .widget {
+  margin-bottom: 0;
 }
-@media screen and (max-width: 980px) {
-  .home #guides li {
-    width: 31.62393162393162%;
-  }
+.home #top .widget_media_image {
+  flex-basis: 10em;
 }
-@media screen and (max-width: 768px) {
-  .home #courses li,
-  .home #guides li {
-    width: 48%;
-    margin-left: 1%;
-    margin-right: 1%;
-  }
-  .home #extras aside {
-    width: 100%;
-    float: none;
+@media (max-width: 768px) {
+  .home #top .widget_media_image {
+    display: none;
   }
 }
-@media screen and (max-width: 480px) {
-  .home #courses li,
-  .home #guides li {
-    width: 100%;
-    margin-left: 0;
-    margin-right: 0;
-  }
-  .home #main {
-    margin-top: 0;
-  }
+.home #top .widget_text {
+  flex-basis: 30em;
+}
+.home #guides h2 {
+  text-align: center;
+}
+.home #guides .description {
+  margin: 0 auto;
+  max-width: 30em;
+}
+.home #guides-container {
+  margin-top: 5vw;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: flex-start;
+}
+.home #guides-container .widget {
+  flex: 0 1 290px;
 }

--- a/wp-content/themes/cjet/homepages/assets/css/cjet.css
+++ b/wp-content/themes/cjet/homepages/assets/css/cjet.css
@@ -1,9 +1,9 @@
-.home #top,
+.home #biggo,
 .home #guides {
   clear: both;
   padding: 5vw 2vw;
 }
-.home #top .widget,
+.home #biggo .widget,
 .home #guides .widget {
   display: inline-block;
   margin-right: 0.85470085%;
@@ -12,24 +12,24 @@
   vertical-align: top;
   text-align: left;
 }
-.home #top span[data-picture],
+.home #biggo span[data-picture],
 .home #guides span[data-picture] {
   max-width: 100%;
   height: auto;
 }
-.home #top h2,
+.home #biggo h2,
 .home #guides h2 {
   font-size: 20px;
   font-size: calc( 10px + 2vw );
   margin-bottom: 12px;
 }
-.home #top h2 a,
+.home #biggo h2 a,
 .home #guides h2 a,
-.home #top p a,
+.home #biggo p a,
 .home #guides p a {
   color: #1c1c1c;
 }
-.home #top .widgettitle,
+.home #biggo .widgettitle,
 .home #guides .widgettitle {
   font-size: 24px;
   margin-bottom: 4px;
@@ -37,28 +37,28 @@
   color: #0089bb;
   text-transform: none;
 }
-.home #top p,
+.home #biggo p,
 .home #guides p {
   font-size: 15px;
 }
-.home #top {
+.home #biggo {
   background-color: #edf1f4;
   display: flex;
   align-items: center;
   justify-content: center;
 }
-.home #top .widget {
+.home #biggo .widget {
   margin-bottom: 0;
 }
-.home #top .widget_media_image {
+.home #biggo .widget_media_image {
   flex-basis: 10em;
 }
 @media (max-width: 768px) {
-  .home #top .widget_media_image {
+  .home #biggo .widget_media_image {
     display: none;
   }
 }
-.home #top .widget_text {
+.home #biggo .widget_text {
   flex-basis: 30em;
 }
 .home #guides h2 {

--- a/wp-content/themes/cjet/homepages/assets/css/cjet.css
+++ b/wp-content/themes/cjet/homepages/assets/css/cjet.css
@@ -64,6 +64,23 @@
 .home #guides h2 {
   text-align: center;
 }
+.home #guides h2::before,
+.home #guides h2::after {
+  display: inline-block;
+  vertical-align: center;
+  width: 4em;
+  height: 0.23em;
+  background-color: #ff8b4d;
+  content: " ";
+  margin-bottom: 0.23em;
+  margin-top: 0.23em;
+}
+.home #guides h2::before {
+  margin-right: 1.3em;
+}
+.home #guides h2::after {
+  margin-left: 1.3em;
+}
 .home #guides .description {
   margin: 0 auto;
   max-width: 30em;
@@ -76,5 +93,5 @@
   align-items: flex-start;
 }
 .home #guides-container .widget {
-  flex: 0 1 290px;
+  flex: 0 1 240px;
 }

--- a/wp-content/themes/cjet/homepages/assets/css/cjet.css
+++ b/wp-content/themes/cjet/homepages/assets/css/cjet.css
@@ -1,10 +1,10 @@
 .home #biggo,
-.home #guides {
+.home #topics {
   clear: both;
   padding: 5vw 2vw;
 }
 .home #biggo .widget,
-.home #guides .widget {
+.home #topics .widget {
   display: inline-block;
   margin-right: 0.85470085%;
   margin-left: 0.85470085%;
@@ -13,24 +13,24 @@
   text-align: left;
 }
 .home #biggo span[data-picture],
-.home #guides span[data-picture] {
+.home #topics span[data-picture] {
   max-width: 100%;
   height: auto;
 }
 .home #biggo h2,
-.home #guides h2 {
+.home #topics h2 {
   font-size: 20px;
   font-size: calc( 10px + 2vw );
   margin-bottom: 12px;
 }
 .home #biggo h2 a,
-.home #guides h2 a,
+.home #topics h2 a,
 .home #biggo p a,
-.home #guides p a {
+.home #topics p a {
   color: #1c1c1c;
 }
 .home #biggo .widgettitle,
-.home #guides .widgettitle {
+.home #topics .widgettitle {
   font-size: 24px;
   margin-bottom: 4px;
   line-height: 1.2;
@@ -38,7 +38,7 @@
   text-transform: none;
 }
 .home #biggo p,
-.home #guides p {
+.home #topics p {
   font-size: 15px;
 }
 .home #biggo {
@@ -61,11 +61,11 @@
 .home #biggo .widget_text {
   flex-basis: 30em;
 }
-.home #guides h2 {
+.home #topics h2 {
   text-align: center;
 }
-.home #guides h2::before,
-.home #guides h2::after {
+.home #topics h2::before,
+.home #topics h2::after {
   display: inline-block;
   vertical-align: center;
   width: 4em;
@@ -75,23 +75,23 @@
   margin-bottom: 0.23em;
   margin-top: 0.23em;
 }
-.home #guides h2::before {
+.home #topics h2::before {
   margin-right: 1.3em;
 }
-.home #guides h2::after {
+.home #topics h2::after {
   margin-left: 1.3em;
 }
-.home #guides .description {
+.home #topics .description {
   margin: 0 auto;
   max-width: 30em;
 }
-.home #guides-container {
+.home #topics-container {
   margin-top: 5vw;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
   align-items: flex-start;
 }
-.home #guides-container .widget {
+.home #topics-container .widget {
   flex: 0 1 240px;
 }

--- a/wp-content/themes/cjet/homepages/assets/less/cjet.less
+++ b/wp-content/themes/cjet/homepages/assets/less/cjet.less
@@ -1,27 +1,12 @@
 @import "../../../../inn/less/variables.less";
 
 .home {
-  .stories article {
-    border-bottom: none;
-    img.attachment-medium {
-	  max-width: 100%;
-    }
-  }
-  #courses,
+  #top,
   #guides {
     clear: both;
-    > h1,
-    > .description {
-      text-align: center;
-    }
-    ul {
-      margin: 0;
-      padding: 0;
-      text-align: left;
-      overflow: hidden; //clearfix
-      font-size: 0;	// inline-block spacing hack
-    }
-    li {
+    padding: 5vw 2vw;
+
+    .widget {
       display: inline-block;
       margin-right: percentage( 10 / 1170 );
       margin-left: percentage( 10 / 1170 );
@@ -33,86 +18,63 @@
       max-width: 100%;
       height: auto;
     }
-    br {
-      clear: left;
+    h2 {
+      font-size: 20px;
+      font-size: ~"calc( 10px + 2vw )";
+      margin-bottom: 12px;
     }
-    h1 {
-	  font-size: 40px;
-	  margin-bottom: 12px;
+    h2 a, p a {
+      color: @black;
     }
-    h4 {
-	  font-size: 24px;
-	  margin-bottom: 4px;
-	  line-height: 1.2;
+    .widgettitle {
+      font-size: 24px;
+      margin-bottom: 4px;
+      line-height: 1.2;
+      color: @blue;
+      text-transform: none;
     }
     p {
-	  font-size: 15px;
+      font-size: 15px;
     }
   }
-  #extras {
-    margin-bottom: 24px;
-    .widget p,
-    .widget ul,
-    .largo-recent-posts h5 {
-	  padding: 0;
-    }
-    .widget p {
-	  font-size: 13.04px;
-	  margin-bottom: 4px;
-	  &.more-link {
-	    font-weight: bold;
-	  }
-    }
-  }
-  #courses li {
-    width: 31.62393162393162%;
-  }
-  #guides li {
-    width: percentage( .25 * (1090.0/1170) );
-  }
-  #extras {
+  #top {
     background-color: @xltgray;
-    padding: 10px;
-    overflow: hidden;
-    > aside {
-      box-sizing: border-box;
-      padding: 10px;
-      width: 33.3333%;
-      float: left;
-      border-top: 0;
-    }
-  }
-}
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
-@media screen and (max-width: 980px) {
-  .home #guides li {
-    width: 31.62393162393162%;
-  }
-}
-@media screen and (max-width: 768px) {
-  .home {
-    #courses li,
-    #guides li {
-	  width: 48%;
-      margin-left: 1%;
-      margin-right:1%;
+    .widget {
+      margin-bottom: 0;
     }
-    #extras aside {
-	  width: 100%;
-	  float: none;
+    .widget_media_image {
+      flex-basis: 10em;
+      @media ( max-width: 768px ) {
+        display: none;
+      }
+    }
+    .widget_text {
+      flex-basis: 30em;
     }
   }
-}
-@media screen and (max-width: 480px) {
-  .home {
-    #courses li,
-    #guides li {
-      width: 100%;
-      margin-left: 0;
-      margin-right: 0;
+  #guides {
+    h2 {
+      text-align: center;
     }
-    #main {
-      margin-top: 0;
+    .description {
+      margin: 0 auto;
+      max-width: 30em;
+    }
+  }
+  #guides-container {
+    margin-top: 5vw;
+
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: flex-start;
+
+    .widget {
+      flex: 0 1 290px;
     }
   }
 }

--- a/wp-content/themes/cjet/homepages/assets/less/cjet.less
+++ b/wp-content/themes/cjet/homepages/assets/less/cjet.less
@@ -1,7 +1,7 @@
 @import "../../../../inn/less/variables.less";
 
 .home {
-  #top,
+  #biggo,
   #guides {
     clear: both;
     padding: 5vw 2vw;
@@ -37,7 +37,7 @@
       font-size: 15px;
     }
   }
-  #top {
+  #biggo {
     background-color: @xltgray;
     display: flex;
     align-items: center;

--- a/wp-content/themes/cjet/homepages/assets/less/cjet.less
+++ b/wp-content/themes/cjet/homepages/assets/less/cjet.less
@@ -2,7 +2,7 @@
 
 .home {
   #biggo,
-  #guides {
+  #topics {
     clear: both;
     padding: 5vw 2vw;
 
@@ -56,7 +56,7 @@
       flex-basis: 30em;
     }
   }
-  #guides {
+  #topics {
     h2 {
       text-align: center;
       &::before,
@@ -82,7 +82,7 @@
       max-width: 30em;
     }
   }
-  #guides-container {
+  #topics-container {
     margin-top: 5vw;
 
     display: flex;

--- a/wp-content/themes/cjet/homepages/assets/less/cjet.less
+++ b/wp-content/themes/cjet/homepages/assets/less/cjet.less
@@ -59,6 +59,23 @@
   #guides {
     h2 {
       text-align: center;
+      &::before,
+      &::after {
+        display: inline-block;
+        vertical-align: center;
+        width: 4em;
+        height: 0.23em;
+        background-color: @orange;
+        content: " ";
+        margin-bottom: 0.23em;
+        margin-top: 0.23em;
+      }
+      &::before {
+        margin-right: 1.3em;
+      }
+      &::after {
+        margin-left: 1.3em;
+      }
     }
     .description {
       margin: 0 auto;
@@ -74,7 +91,7 @@
     align-items: flex-start;
 
     .widget {
-      flex: 0 1 290px;
+      flex: 0 1 240px;
     }
   }
 }

--- a/wp-content/themes/cjet/homepages/templates/cjet.php
+++ b/wp-content/themes/cjet/homepages/templates/cjet.php
@@ -2,8 +2,8 @@
 	<?php dynamic_sidebar( 'homepage-top' ); ?>
 </section>
 
-<section id="guides">
-	<h2><?php _e('Explore guides', 'cjet'); ?></h2>
+<section id="topics">
+	<h2><?php _e('Explore Topics', 'cjet'); ?></h2>
 
 	<p class="description"><?php
 		if ( of_get_option('cjet_guides_intro') ) {
@@ -17,7 +17,7 @@
 	?></p>
 
 
-	<div id="guides-container">
-		<?php dynamic_sidebar( 'homepage-guides' ); ?>
+	<div id="topics-container">
+		<?php dynamic_sidebar( 'homepage-topics' ); ?>
 	</div>
-</section><!-- #guides -->
+</section><!-- #topics -->

--- a/wp-content/themes/cjet/homepages/templates/cjet.php
+++ b/wp-content/themes/cjet/homepages/templates/cjet.php
@@ -1,70 +1,23 @@
-<?php
-
-$courses_parent = get_page_by_path('courses');
-$guides_parent = get_page_by_path('guides');
-
-$courses = get_pages( array(
-	'sort_column' => 'menu_order',
-	'parent' => $courses_parent->ID
-));
-
-$guides = get_pages( array(
-	'sort_column' => 'post_date',
-	'sort_order' => 'DESC',
-	'parent' => $guides_parent->ID
-));
-?>
-
-<section id="courses">
-	<h1><?php _e("Online Courses", 'cjet'); ?></h1>
-	<p class="description"><?php
-		if ( of_get_option('cjet_courses_intro') ) {
-			echo of_get_option('cjet_courses_intro');
-		} else {
-			_e('Edit this description under Appearance > Theme Options.', 'cjet');
-		}
-	?></p>
-	<ul>
-	<?php
-		foreach ( $courses as $course ) :	?>
-			<li>
-				<article>
-					<a href="<?php echo get_permalink( $course->ID ); ?>" title="Permalink to <?php echo esc_attr( $course->post_title ); ?>"><?php echo apply_filters('the_content', get_the_post_thumbnail( $course->ID, 'large' ) ); ?></a>
-					<h4><a href="<?php echo get_permalink( $course->ID ); ?>" title="Permalink to <?php echo esc_attr( $course->post_title ); ?>"><?php echo $course->post_title; ?></a></h4>
-					<p><?php echo $course->post_excerpt; ?></p>
-				</article>
-			</li>
-			<?php
-		endforeach;
-	?>
-	</ul>
-</section><!-- #courses -->
-
-<section id="extras">
-	<?php dynamic_sidebar( 'homepage-callout' ); ?>
+<section id="top">
+	<?php dynamic_sidebar( 'homepage-top' ); ?>
 </section>
 
 <section id="guides">
-	<h1><?php _e('Guides', 'cjet'); ?></h1>
+	<h2><?php _e('Explore guides', 'cjet'); ?></h2>
+
 	<p class="description"><?php
 		if ( of_get_option('cjet_guides_intro') ) {
 			echo of_get_option('cjet_guides_intro');
 		} else {
-			_e('Edit this description under Appearance > Theme Options.', 'cjet');
+			printf(
+				'<!-- %1$s -->',
+				_e('Edit this description under Appearance > Theme Options.', 'cjet')
+			);
 		}
 	?></p>
-	<ul>
-	<?php
-		foreach ( $guides as $guide ) : ?>
-			<li>
-				<article>
-					<a href="<?php echo get_permalink( $guide->ID ); ?>" title="Permalink to <?php echo esc_attr( $guide->post_title ); ?>"><?php echo apply_filters('the_content', get_the_post_thumbnail( $guide->ID, 'medium' ) ); ?></a>
-					<h4><a href="<?php echo get_permalink( $guide->ID ); ?>" title="Permalink to <?php echo esc_attr( $guide->post_title ); ?>"><?php echo $guide->post_title; ?></a></h4>
-					<p><?php echo $guide->post_excerpt; ?></p>
-				</article>
-			</li>
-			<?php
-		endforeach;
-	?>
-	</ul>
+
+
+	<div id="guides-container">
+		<?php dynamic_sidebar( 'homepage-guides' ); ?>
+	</div>
 </section><!-- #guides -->

--- a/wp-content/themes/cjet/homepages/templates/cjet.php
+++ b/wp-content/themes/cjet/homepages/templates/cjet.php
@@ -1,4 +1,4 @@
-<section id="top">
+<section id="biggo">
 	<?php dynamic_sidebar( 'homepage-top' ); ?>
 </section>
 

--- a/wp-content/themes/cjet/inc/sidebars.php
+++ b/wp-content/themes/cjet/inc/sidebars.php
@@ -11,8 +11,8 @@ function cjet_register_sidebars() {
 	) );
 
 	register_sidebar( array(
-		'name' 			=> __( 'Homepage Guides', 'cjet' ),
-		'id' 			=> 'homepage-guides',
+		'name' 			=> __( 'Homepage Topics', 'cjet' ),
+		'id' 			=> 'homepage-topics',
 		'description' 	=> __( 'This is the cluster of items on the bottom of the homepage.', 'cjet' ),
 		'before_widget' => '<div id="%1$s" class="%2$s clearfix">',
 		'after_widget' 	=> "</div aside>",

--- a/wp-content/themes/cjet/inc/sidebars.php
+++ b/wp-content/themes/cjet/inc/sidebars.php
@@ -1,11 +1,21 @@
 <?php
 function cjet_register_sidebars() {
 	register_sidebar( array(
-		'name' 			=> __( 'Homepage Callout', 'cjet' ),
-		'id' 			=> 'homepage-callout',
-		'description' 	=> __( 'Homepage Callout Section', 'cjet' ),
+		'name' 			=> __( 'Homepage Top', 'cjet' ),
+		'id' 			=> 'homepage-top',
+		'description' 	=> __( '', 'cjet' ),
 		'before_widget' => '<aside id="%1$s" class="%2$s clearfix">',
 		'after_widget' 	=> "</aside>",
+		'before_title' 	=> '<h2 class="">',
+		'after_title' 	=> '</h2>',
+	) );
+
+	register_sidebar( array(
+		'name' 			=> __( 'Homepage Guides', 'cjet' ),
+		'id' 			=> 'homepage-guides',
+		'description' 	=> __( 'This is the cluster of items on the bottom of the homepage.', 'cjet' ),
+		'before_widget' => '<div id="%1$s" class="%2$s clearfix">',
+		'after_widget' 	=> "</div aside>",
 		'before_title' 	=> '<h3 class="widgettitle">',
 		'after_title' 	=> '</h3>',
 	) );


### PR DESCRIPTION
## Changes

- removes existing homepage content
- styles homepage image widgets, custom HTML widgets, and Largo Image Widgets for display of links as described in #70 and #78 to match the mockup https://drive.google.com/open?id=1P3m2OErNfjh6uHI9UZQ9QRXvVBjGX5cm

## Questions

- [ ] What can we use for logos?

## Screenshots

In these images, the top grey area is made from an Image widget, next to a Custom HTML widget with these contents:

```html
<p>
	<a href="https://learn-inn-org.inndevlearn.wpengine.com/guides/business-resources/">
	Lorem ipsum dolor sit amet, consectr adpiscing elit. Sed dignissim mauris nunc, nec gravida lorem tristique vitae. Sed dignissim mauris nunc, nec gravida lrem tristique vitae, nec gravida lorem tristique vitae.
	</a>
</p>
```

The four widgets across the bottom are Largo Image Widgets, with descriptions set to text like this:

```html
<h3 class="widgettitle"> Thing!</h3>
<p>This links out to the thing that we were afraid of. It's a scary link.</p>
```

The images used are placeholders as they were the only square images that I had on my hard drive at the time. 

![Screen Shot 2019-06-03 at 16 23 25 ](https://user-images.githubusercontent.com/1754187/58832095-30f3c880-861c-11e9-9326-84ee2a826c9d.png)

![Screen Shot 2019-06-03 at 16 31 56 ](https://user-images.githubusercontent.com/1754187/58832546-2a198580-861d-11e9-98ac-385006316402.png)
![Screen Shot 2019-06-03 at 16 32 12 ](https://user-images.githubusercontent.com/1754187/58832547-2ab21c00-861d-11e9-9de1-b96863b0f9b2.png)
