### PR TITLE
Styles QA pass

### DIFF
--- a/wp-content/themes/cjet/css/style.css
+++ b/wp-content/themes/cjet/css/style.css
@@ -302,124 +302,9 @@ a.btn.btn.search-submit,
     max-width: 90%;
   }
 }
-#breadcrumbs {
-  font-family: "Montserrat", "Raleway", helvetica, sans-serif;
-  font-weight: 700;
-}
-#site-header,
-.home #site-header {
-  min-height: 0;
-}
-#site-header {
-  padding: 24px 0;
-  margin: 0 0 40px 0;
-  border-bottom: 8px solid #eee;
-}
-#site-header img {
-  max-width: 30%;
-}
-#site-header h5 {
-  margin: 0 auto;
-  font-size: 22px;
-}
-@media (max-width: 1100px) {
-  #site-header h5 {
-    font-size: 20px;
-  }
-}
-@media (max-width: 900px) {
-  #site-header h5 {
-    font-size: 18px;
-  }
-}
-#site-header .cjet-header-grid {
-  display: inline-grid;
-  width: 50%;
-  height: 100%;
-  justify-content: center;
-  vertical-align: bottom;
-}
-#site-header .cjet-header-grid:last-of-type {
-  width: 20%;
-  justify-content: end;
-}
-#site-header #header-search {
-  justify-content: end;
-  display: inherit;
-  margin-bottom: 25px;
-  margin-left: 20px;
-}
-#site-header #header-search input {
-  border-color: #000;
-  padding: 7px 15px;
-  width: 250px;
-}
-#site-header #header-search input::placeholder {
-  color: #000;
-}
-@media (max-width: 999px) {
-  #site-header #header-search input {
-    max-width: 200px;
-  }
-}
-#site-header #main-nav {
-  border: none;
-}
-#site-header #main-nav .nav {
-  float: right;
-}
-#site-header #main-nav .navbar-inner {
-  background-color: transparent;
-}
-#site-header #main-nav a {
-  color: #0089bb;
-  padding-right: 0;
-  font-size: 15px;
-}
-#site-header #main-nav a:hover {
-  background: none;
-}
-@media (max-width: 900px) {
-  #site-header #main-nav a {
-    font-size: 14px;
-  }
-}
-#site-header #main-nav .dropdown-menu a {
-  padding-right: 10px;
-}
-#main {
-  margin-top: 8px;
-}
-#content {
-  margin-left: 0;
-}
-#breadcrumbs {
-  margin-bottom: 24px;
-}
-#branding img {
-  margin: 24px auto 18px;
-  display: block;
-  max-width: 400px;
-  padding: 0 5%;
-  width: 90%;
-}
-#top-nav li.main_site_home_link {
-  padding-top: 2px;
-  font-size: inherit;
-  font-weight: inherit;
-}
-#top-nav li.main_site_home_link a {
-  color: #fff;
-}
-#top-nav li.main_site_home_link a:hover {
-  color: #d9d9d9;
-}
 /**
  * Styles pertaining to guide.php and article.php
  */
-body.normal.page #content.guide-page {
-  margin-left: 0;
-}
 .guide-page .author-posts-link {
   display: none;
 }
@@ -437,10 +322,6 @@ body.normal.page #content.guide-page {
   box-sizing: border-box;
   justify-content: center;
   height: 100%;
-}
-.guide-page .pager h5.top-page {
-  margin-bottom: 0;
-  font-size: 21px;
 }
 @media (max-width: 769px) {
   .guide-page .pager .next,
@@ -794,6 +675,83 @@ details.guide-form[open] .gform_wrapper ul.gform_fields li.gfield {
 .home #site-header {
   min-height: 0;
 }
+#site-header {
+  padding: 24px 0;
+  margin: 0 0 40px 0;
+  border-bottom: 8px solid #eee;
+}
+#site-header img {
+  max-width: 30%;
+}
+#site-header h5 {
+  margin: 0 auto;
+  font-size: 22px;
+}
+@media (max-width: 1100px) {
+  #site-header h5 {
+    font-size: 20px;
+  }
+}
+@media (max-width: 900px) {
+  #site-header h5 {
+    font-size: 18px;
+  }
+}
+#site-header .cjet-header-grid {
+  display: inline-grid;
+  width: 50%;
+  height: 100%;
+  justify-content: center;
+  vertical-align: bottom;
+}
+#site-header .cjet-header-grid:last-of-type {
+  width: 20%;
+  justify-content: end;
+}
+#site-header #header-search {
+  justify-content: end;
+  display: inherit;
+  margin-bottom: 25px;
+  margin-left: 20px;
+}
+#site-header #header-search input {
+  border-color: #000;
+  padding: 7px 15px;
+  width: 250px;
+}
+#site-header #header-search input::placeholder {
+  color: #000;
+}
+@media (max-width: 999px) {
+  #site-header #header-search input {
+    max-width: 200px;
+  }
+}
+#site-header #main-nav {
+  border: none;
+}
+#site-header #main-nav .nav {
+  float: right;
+}
+#site-header #main-nav .navbar-inner {
+  background-color: transparent;
+}
+#site-header #main-nav a {
+  color: #0089bb;
+  padding-right: 0;
+  font-size: 15px;
+}
+#site-header #main-nav a:hover {
+  background: none;
+}
+@media (max-width: 900px) {
+  #site-header #main-nav a {
+    font-size: 14px;
+  }
+}
+#site-header #main-nav .dropdown-menu a {
+  padding-right: 10px;
+}
 @media screen and (max-width: 769px) {
   #main {
     margin-top: 56px;
@@ -808,6 +766,17 @@ details.guide-form[open] .gform_wrapper ul.gform_fields li.gfield {
   max-width: 400px;
   padding: 0 5%;
   width: 90%;
+}
+#top-nav li.main_site_home_link {
+  padding-top: 2px;
+  font-size: inherit;
+  font-weight: inherit;
+}
+#top-nav li.main_site_home_link a {
+  color: #fff;
+}
+#top-nav li.main_site_home_link a:hover {
+  color: #d9d9d9;
 }
 body.normal.page #content.guide-page {
   margin-left: 0;

--- a/wp-content/themes/cjet/css/style.css
+++ b/wp-content/themes/cjet/css/style.css
@@ -658,13 +658,22 @@ details.guide-form[open] summary::after {
 }
 details.guide-form[open] .gform_wrapper {
   color: #1c1c1c;
-  padding: 0 5px;
+  padding: 0 5px 5px 5px;
   margin: 0;
 }
 details.guide-form[open] .gform_wrapper ul.gform_fields li.gfield {
   padding-right: 0;
 }
-details.guide-form input[type=submit] {
+details.guide-form .gfield_html a {
+  text-decoration: underline;
+}
+details.guide-form .gfield_html a:hover {
+  color: #0089bb;
+}
+details.guide-form .gform_footer {
+  padding: 0;
+}
+details.guide-form .gform_footer input[type=submit] {
   font-family: "Montserrat", "Raleway", helvetica, sans-serif;
   color: #005270;
   text-shadow: none;
@@ -678,18 +687,18 @@ details.guide-form input[type=submit] {
   margin: 0;
   width: 100%;
 }
-details.guide-form input[type=submit]:hover {
+details.guide-form .gform_footer input[type=submit]:hover {
   background-color: #00719b;
   color: #fff;
 }
-details.guide-form input[type=submit].btn-primary {
+details.guide-form .gform_footer input[type=submit].btn-primary {
   color: #fff;
   background-color: #ff8b4d;
 }
-details.guide-form input[type=submit].btn-primary:hover {
+details.guide-form .gform_footer input[type=submit].btn-primary:hover {
   background-color: #ff762d;
 }
-details.guide-form input[type=submit].btn.search-submit {
+details.guide-form .gform_footer input[type=submit].btn.search-submit {
   padding: 4px 10px;
 }
 body.normal.page #content.guide-page {

--- a/wp-content/themes/cjet/css/style.css
+++ b/wp-content/themes/cjet/css/style.css
@@ -308,6 +308,9 @@ a.btn.btn.search-submit,
 .guide-page .author-posts-link {
   display: none;
 }
+.guide-page .entry-title {
+  margin-bottom: 1em;
+}
 .guide-page .entry-content .widget {
   padding: 15px 0;
 }
@@ -655,11 +658,42 @@ details.guide-form[open] summary::after {
 }
 details.guide-form[open] .gform_wrapper {
   color: #1c1c1c;
-  padding: 0 2px;
+  padding: 0 5px;
   margin: 0;
 }
 details.guide-form[open] .gform_wrapper ul.gform_fields li.gfield {
   padding-right: 0;
+}
+details.guide-form input[type=submit] {
+  font-family: "Montserrat", "Raleway", helvetica, sans-serif;
+  color: #005270;
+  text-shadow: none;
+  border: none;
+  text-transform: uppercase;
+  font-weight: bold;
+  padding: 12px 24px;
+  background-color: #0089bb;
+  color: #fff;
+  border-radius: 0;
+  margin: 0;
+  width: 100%;
+}
+details.guide-form input[type=submit]:hover {
+  background-color: #00719b;
+  color: #fff;
+}
+details.guide-form input[type=submit].btn-primary {
+  color: #fff;
+  background-color: #ff8b4d;
+}
+details.guide-form input[type=submit].btn-primary:hover {
+  background-color: #ff762d;
+}
+details.guide-form input[type=submit].btn.search-submit {
+  padding: 4px 10px;
+}
+body.normal.page #content.guide-page {
+  margin-left: 0;
 }
 #breadcrumbs {
   font-family: "Montserrat", "Raleway", helvetica, sans-serif;
@@ -778,6 +812,7 @@ details.guide-form[open] .gform_wrapper ul.gform_fields li.gfield {
 #top-nav li.main_site_home_link a:hover {
   color: #d9d9d9;
 }
-body.normal.page #content.guide-page {
-  margin-left: 0;
+.entry-content p {
+  font-family: "Montserrat", "Raleway", helvetica, sans-serif;
+  font-size: 18px;
 }

--- a/wp-content/themes/cjet/guides.php
+++ b/wp-content/themes/cjet/guides.php
@@ -143,20 +143,23 @@ $top_page = FALSE;
 							} else {
 								$link_text = __('Start Reading', 'cjet');
 							}
-							printf( '<div class="next"><a href="%1$s"><h5 class="top-page">%2$s &rarr;</h5></a></div>',
+							printf(
+								'<div class="next"><a href="%1$s" rel="next"><i class="dashicons dashicons-arrow-right-alt"></i><span class="meta-nav">%2$s</span></a></div>',
 								get_permalink( $next_id ),
 								$link_text
 							);
 						} else {
 							if (!empty($prev_id)) {
-								printf( '<div class="previous"><a href="%1$s" rel="prev"><i class="dashicons dashicons-arrow-left-alt"></i><span class="meta-nav">%2$s</span></a></div>',
+								printf(
+									'<div class="previous"><a href="%1$s" rel="prev"><i class="dashicons dashicons-arrow-left-alt"></i><span class="meta-nav">%2$s</span></a></div>',
 									get_permalink( $prev_id ),
 									get_the_title($prev_id)
 								);
 							}
 
 							if (!empty($next_id)) {
-								printf( '<div class="next"><a href="%1$s" rel="next"><i class="dashicons dashicons-arrow-right-alt"></i><span class="meta-nav">%2$s</span></a></div>',
+								printf(
+									'<div class="next"><a href="%1$s" rel="next"><i class="dashicons dashicons-arrow-right-alt"></i><span class="meta-nav">%2$s</span></a></div>',
 									get_permalink( $next_id ),
 									get_the_title( $next_id )
 								);

--- a/wp-content/themes/cjet/less/guides.less
+++ b/wp-content/themes/cjet/less/guides.less
@@ -368,7 +368,7 @@ details.guide-form{
 
     .gform_wrapper {
       color: @black;
-      padding: 0 5px;
+      padding: 0 5px 5px 5px;
       margin: 0;
 
       ul.gform_fields li.gfield {
@@ -376,10 +376,21 @@ details.guide-form{
       }
     }
   }
-  input[type=submit] {
-    .btn;
-    margin: 0;
-    width: 100%;
+  .gfield_html a {
+    text-decoration: underline;
+    &:hover {
+      color: @blue;
+    }
+  }
+  .gform_footer {
+    padding: 0;
+
+    // within .gform_footer because it must override the Gravity Forms CSS which is this specific.
+    input[type=submit] {
+      .btn;
+      margin: 0;
+      width: 100%;
+    }
   }
 }
 body.normal.page #content.guide-page {

--- a/wp-content/themes/cjet/less/guides.less
+++ b/wp-content/themes/cjet/less/guides.less
@@ -21,10 +21,6 @@
       justify-content: center;
       height: 100%;
     }
-    h5.top-page {
-      margin-bottom: 0;
-      font-size: 21px;
-    }
     @media (max-width:@breakpoint) {
       .next,
       .previous {

--- a/wp-content/themes/cjet/less/guides.less
+++ b/wp-content/themes/cjet/less/guides.less
@@ -6,6 +6,9 @@
   .author-posts-link {
     display: none;
   }
+  .entry-title {
+    margin-bottom: 1em;
+  }
   .entry-content .widget {
     padding: 15px 0;
   }
@@ -365,7 +368,7 @@ details.guide-form{
 
     .gform_wrapper {
       color: @black;
-      padding: 0 2px;
+      padding: 0 5px;
       margin: 0;
 
       ul.gform_fields li.gfield {
@@ -373,5 +376,13 @@ details.guide-form{
       }
     }
   }
+  input[type=submit] {
+    .btn;
+    margin: 0;
+    width: 100%;
+  }
+}
+body.normal.page #content.guide-page {
+  margin-left: 0;
 }
 

--- a/wp-content/themes/cjet/less/style.less
+++ b/wp-content/themes/cjet/less/style.less
@@ -123,6 +123,10 @@
     }
   }
 }
-body.normal.page #content.guide-page {
-  margin-left: 0;
+
+.entry-content {
+  p {
+    font-family: @sans;
+    font-size: 18px;
+  }
 }


### PR DESCRIPTION
## Changes

- Matches the markup/styles for the next arrow on the first page of a guide with the styles used on the rest of the guide.
- Increases margin-bottom for headlines on guide pages from `12px` to `1em` ~= `44px`
- Increases padding on the feedback form
- Styles the feedback form button using `.btn` and makes it blue and full width
- Decreases guide font size from `19.22px` (Largo default) to `18px` and makes it sans-serif