### PR TITLE
Additional changes to article template

### DIFF
--- a/wp-content/themes/cjet/articles.php
+++ b/wp-content/themes/cjet/articles.php
@@ -16,6 +16,7 @@ $top_page = FALSE;
 			$page_type_id = end($ancestors); // the topmost parent is actually the "articles" page so let's back it up one
 			$page_type = get_post( $page_type_id )->post_name;
 
+			// in the future, it may make sense to make this === into <=
 			if ( count($ancestors) === 1 ) {
 				// this is the main page of the article so we can just list all of its children
 				$top_page = TRUE;

--- a/wp-content/themes/cjet/articles.php
+++ b/wp-content/themes/cjet/articles.php
@@ -14,70 +14,22 @@ $top_page = FALSE;
 			$this_page_id = $post->ID;
 			$ancestors = get_post_ancestors( $this_page_id );
 			$page_type_id = end($ancestors); // the topmost parent is actually the "articles" page so let's back it up one
-			$article_type = get_post( $page_type_id )->post_name;
+			$page_type = get_post( $page_type_id )->post_name;
 
 			if ( count($ancestors) === 1 ) {
 				// this is the main page of the article so we can just list all of its children
 				$top_page = TRUE;
-				$article_parent_id = $post->ID;
+				$page_parent_id = $post->ID;
 			} else {
 				// it's not and we need to do get the full page tree
-				$article_parent_id = prev($ancestors); // much better
+				$page_parent_id = prev($ancestors); // much better
 			}
 
-			// now get the complete tree of child pages for the article's top page
-			$children = wp_list_pages('title_li=&child_of=' . $article_parent_id . '&echo=0');
-			$attachments = get_posts( array(
-				'post_type' => 'attachment',
-				'posts_per_page' => -1,
-				'post_parent' => $article_parent_id,
-				'exclude'     => get_post_thumbnail_id( $article_parent_id ), //don't get the featured image
-			) );
 			?>
 
-			<nav class="guide-nav span3">
-				<!-- .btn-navbar is used as the toggle for collapsed navbar content -->
-				<div class="container clearfix">
-					<a class="btn btn-navbar toggle-nav-bar" title="More">
-						<div class="bars">
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-						</div>
-					</a>
-
-					<?php if ( $top_page ) { ?>
-						<h4 class="guide-top">
-							<?php esc_html_e( 'In This ' . ucfirst( rtrim( $article_type, 's') ), 'cjet' ); ?>
-						</h4>
-					<?php } else { ?>
-						<h4 class="guide-top"><a href="<?php echo get_permalink($article_parent_id); ?>"><?php echo get_the_title($article_parent_id); ?></a></h4>
-					<?php } ?>
-
-					<ul class="guide-tree">
-						<?php echo $children; ?>
-					</ul>
-
-					<?php
-					// on interior article pages, list resources attached to the parent article page
-					if ( $attachments ) : ?>
-					<div class="resources">
-						<h4><?php _e('Resources', 'cjet'); ?></h4>
-						<ul class="guide-resources"><?php
-							foreach ( $attachments as $attachment ) {
-								//print_r( $attachment );
-								$class = "mime-" . sanitize_title( $attachment->post_mime_type );
-								echo '<li class="' . $class . ' data-design-thumbnail">';
-								echo cjet_format_attachment_link( $attachment->ID );
-								echo '</li>';
-							}
-						?>
-						</ul></div>
-							<?php
-					endif;	// resources links
-					?>
-				</div>
-			</nav>
+			<?php
+				include( locate_template( 'partials/nav-guide-sidebar.php' ) );
+			?>
 
 			<article id="post-<?php the_ID(); ?>" <?php post_class('clearfix span9'); ?>>
 
@@ -93,7 +45,7 @@ $top_page = FALSE;
 					// if we're on a article "top" page, show author information and whatnot
 					// we can leverage Largo's author info widget here
 
-						if ( $top_page && $article_type == 'courses' ) {
+						if ( $top_page && $page_type == 'courses' ) {
 							echo '<h3 class="widgettitle guide-author">' . __( 'Course Instructor', 'cjet' ) . '</h3>';
 						} elseif ( $top_page ) {
 							$author_label = '<h3 class="widgettitle guide-author">' . __( 'Guide Author', 'cjet' ) . '</h3>';

--- a/wp-content/themes/cjet/css/style.css
+++ b/wp-content/themes/cjet/css/style.css
@@ -473,7 +473,7 @@ a.btn.btn.search-submit,
 .guide-nav .guide-top a {
   color: #0089bb;
 }
-.guide-nav .widget {
+.guide-nav li + .widget {
   margin-top: 2em;
 }
 .guide-nav .widget:last-child {

--- a/wp-content/themes/cjet/guides.php
+++ b/wp-content/themes/cjet/guides.php
@@ -14,84 +14,22 @@ $top_page = FALSE;
 			$this_page_id = $post->ID;
 			$ancestors = get_post_ancestors( $this_page_id );
 			$page_type_id = end($ancestors); // the topmost parent is actually the "guides" page so let's back it up one
-			$guide_type = get_post( $page_type_id )->post_name;
+			$page_type = get_post( $page_type_id )->post_name;
 
 			if ( count($ancestors) === 1 ) {
 				// this is the main page of the guide so we can just list all of its children
 				$top_page = TRUE;
-				$guide_parent_id = $post->ID;
+				$page_parent_id = $post->ID;
 			} else {
 				// it's not and we need to do get the full page tree
-				$guide_parent_id = prev($ancestors); // much better
+				$page_parent_id = prev($ancestors); // much better
 			}
 
-			// now get the complete tree of child pages for the guide's top page
-			$children = wp_list_pages('title_li=&child_of=' . $guide_parent_id . '&echo=0');
-
-			/*
-			 * Commented out until we're sure of what we want to do with attachments
-			$attachments = get_posts( array(
-				'post_type' => 'attachment',
-				'posts_per_page' => -1,
-				'post_parent' => $guide_parent_id,
-				'exclude'     => get_post_thumbnail_id( $guide_parent_id ), //don't get the featured image
-			) );
-			*/
 			?>
 
-			<nav class="guide-nav span3">
-				<!-- .btn-navbar is used as the toggle for collapsed navbar content -->
-				<div class="container clearfix">
-					<a class="btn btn-navbar toggle-nav-bar" title="More">
-						<div class="bars">
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-						</div>
-					</a>
-
-					<?php if ( $top_page ) { ?>
-						<h4 class="guide-top">
-							<?php esc_html_e( 'In This ' . ucfirst( rtrim( $guide_type, 's') ), 'cjet' ); ?>
-						</h4>
-					<?php } else { ?>
-						<h4 class="guide-top">
-							<a href="<?php echo esc_attr( get_permalink( $guide_parent_id ) ); ?>">
-								<?php echo get_the_title( $guide_parent_id ); ?>
-							</a>
-						</h4>
-					<?php } ?>
-
-					<ul class="guide-tree">
-						<?php echo $children; ?>
-
-						<?php dynamic_sidebar( 'guide-sidebar-below-toc' ); ?>
-					</ul>
-
-					<?php
-					/*
-					 * Commented out until we're sure of what we want to do with attachments
-					// on interior guide pages, list resources attached to the parent guide page
-					// if ( $attachments ) : ?>
-					<!-- <div class="resources">
-						<h4><?php _e('Related Resources', 'cjet'); ?></h4>
-						<ul class="guide-resources"><?php
-							// foreach ( $attachments as $attachment ) {
-							// 	//print_r( $attachment );
-							// 	$class = "mime-" . sanitize_title( $attachment->post_mime_type );
-							// 	echo '<li class="' . $class . ' data-design-thumbnail">';
-							// 	echo cjet_format_attachment_link( $attachment->ID );
-							// 	echo '</li>';
-							// }
-						?> -->
-						<!-- </ul></div> -->
-							<?php
-					// endif;	// resources links
-
-					*/
-					?>
-				</div>
-			</nav>
+			<?php
+				include( locate_template( 'partials/nav-guide-sidebar.php' ) );
+			?>
 
 			<article id="post-<?php the_ID(); ?>" <?php post_class('clearfix span9'); ?>>
 
@@ -107,7 +45,7 @@ $top_page = FALSE;
 					// if we're on a guide "top" page, show author information and whatnot
 					// we can leverage Largo's author info widget here
 
-						if ( $top_page && $guide_type == 'courses' ) {
+						if ( $top_page && $page_type == 'courses' ) {
 							echo '<h3 class="widgettitle guide-author">' . __( 'Course Instructor', 'cjet' ) . '</h3>';
 						} elseif ( $top_page ) {
 							$author_label = '<h3 class="widgettitle guide-author">' . __( 'Guide Author', 'cjet' ) . '</h3>';
@@ -118,56 +56,11 @@ $top_page = FALSE;
 						}
 					?>
 
-					<?php // in-guide navigation ?>
-					<nav id="nav-below" class="pager post-nav clearfix">
 					<?php
-						$pagelist = get_pages('sort_column=menu_order&sort_order=asc&child_of=' . $guide_parent_id );
-						$pages = array();
-						$pages[] = $guide_parent_id;
-						$prev_id = $next_id = '';
-						foreach ( $pagelist as $page ) {
-						   $pages[] += $page->ID;
-						}
+						// check this template before removing unused variables from this file.
+						include( locate_template( 'partials/nav-guide-footer.php' ) );
+					?>
 
-						$current = array_search(get_the_ID(), $pages);
-						if ( array_key_exists($current-1, $pages)) {
-							$prev_id = $pages[$current-1];
-						}
-						if ( array_key_exists($current+1, $pages)) {
-							$next_id = $pages[$current+1];
-						}
-
-						if ( $top_page ) {
-							if ( $guide_type == 'courses' ) {
-								$link_text = __('Get Started', 'cjet');
-							} else {
-								$link_text = __('Start Reading', 'cjet');
-							}
-							printf(
-								'<div class="next"><a href="%1$s" rel="next"><i class="dashicons dashicons-arrow-right-alt"></i><span class="meta-nav">%2$s</span></a></div>',
-								get_permalink( $next_id ),
-								$link_text
-							);
-						} else {
-							if (!empty($prev_id)) {
-								printf(
-									'<div class="previous"><a href="%1$s" rel="prev"><i class="dashicons dashicons-arrow-left-alt"></i><span class="meta-nav">%2$s</span></a></div>',
-									get_permalink( $prev_id ),
-									get_the_title($prev_id)
-								);
-							}
-
-							if (!empty($next_id)) {
-								printf(
-									'<div class="next"><a href="%1$s" rel="next"><i class="dashicons dashicons-arrow-right-alt"></i><span class="meta-nav">%2$s</span></a></div>',
-									get_permalink( $next_id ),
-									get_the_title( $next_id )
-								);
-							}
-						}
-						?>
-
-					</nav><!-- #nav-below -->
 				</div><!-- .entry-content -->
 
 			</article><!-- #post-<?php the_ID(); ?> -->

--- a/wp-content/themes/cjet/inc/sidebars.php
+++ b/wp-content/themes/cjet/inc/sidebars.php
@@ -23,7 +23,7 @@ function cjet_register_sidebars() {
 	register_sidebar( array(
 		'name'			=> __( 'Guide Sidebar Below Table of Contents', 'cjet' ),
 		'id' 			=> 'guide-sidebar-below-toc',
-		'description' 	=> __( 'Widget area for Guides sidebar. This will appear below the table of contents.', 'cjet' ),
+		'description' 	=> __( 'Widget area for sidebar on pages using the Guide or Article template. This will appear below the table of contents.', 'cjet' ),
 		'before_title' 	=> '<h3 class="widgettitle">',
 		'after_title' 	=> '</h3>',
 	) );

--- a/wp-content/themes/cjet/less/guides.less
+++ b/wp-content/themes/cjet/less/guides.less
@@ -170,8 +170,10 @@
       color: @blue;
     }
   }
-  .widget {
+  li + .widget {
     margin-top: 2em;
+  }
+  .widget {
     &:last-child {
       margin-bottom: 0;
     }

--- a/wp-content/themes/cjet/partials/nav-guide-footer.php
+++ b/wp-content/themes/cjet/partials/nav-guide-footer.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * The previous/next buttons from the nav template.
+ *
+ * Expected variables:
+ *
+ * @param Int $page_parent_id the ID of the parent post of this page
+ * @param Bool $top_page Whether this page is the top page of a guide, according to business logic
+ */
+?>
+<nav id="nav-below" class="pager post-nav clearfix">
+<?php
+	$pagelist = get_pages('sort_column=menu_order&sort_order=asc&child_of=' . $page_parent_id );
+	$pages = array();
+	$pages[] = $page_parent_id;
+	$prev_id = $next_id = '';
+	foreach ( $pagelist as $page ) {
+	   $pages[] += $page->ID;
+	}
+
+	$current = array_search(get_the_ID(), $pages);
+	if ( array_key_exists($current-1, $pages)) {
+		$prev_id = $pages[$current-1];
+	}
+	if ( array_key_exists($current+1, $pages)) {
+		$next_id = $pages[$current+1];
+	}
+
+	if ( $top_page ) {
+		if ( $page_type == 'courses' ) {
+			$link_text = __('Get Started', 'cjet');
+		} else {
+			$link_text = __('Start Reading', 'cjet');
+		}
+		printf(
+			'<div class="next"><a href="%1$s" rel="next"><i class="dashicons dashicons-arrow-right-alt"></i><span class="meta-nav">%2$s</span></a></div>',
+			get_permalink( $next_id ),
+			$link_text
+		);
+	} else {
+		if (!empty($prev_id)) {
+			printf(
+				'<div class="previous"><a href="%1$s" rel="prev"><i class="dashicons dashicons-arrow-left-alt"></i><span class="meta-nav">%2$s</span></a></div>',
+				get_permalink( $prev_id ),
+				get_the_title($prev_id)
+			);
+		}
+
+		if (!empty($next_id)) {
+			printf(
+				'<div class="next"><a href="%1$s" rel="next"><i class="dashicons dashicons-arrow-right-alt"></i><span class="meta-nav">%2$s</span></a></div>',
+				get_permalink( $next_id ),
+				get_the_title( $next_id )
+			);
+		}
+	}
+	?>
+
+</nav><!-- #nav-below -->

--- a/wp-content/themes/cjet/partials/nav-guide-sidebar.php
+++ b/wp-content/themes/cjet/partials/nav-guide-sidebar.php
@@ -5,7 +5,7 @@
  * Expects the following variables to be defined:
  *
  * @param Int|Bool $page_parent_id The parent page of the current Guide
- *
+ * @param String $page_type The type of page it is?
  */
 
 // now get the complete tree of child pages for the guide's top page

--- a/wp-content/themes/cjet/partials/nav-guide-sidebar.php
+++ b/wp-content/themes/cjet/partials/nav-guide-sidebar.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * The Guide Nav Sidebar
+ *
+ * Expects the following variables to be defined:
+ *
+ * @param Int|Bool $page_parent_id The parent page of the current Guide
+ *
+ */
+
+// now get the complete tree of child pages for the guide's top page
+if ( is_int( $page_parent_id ) ) {
+	$children = wp_list_pages('title_li=&child_of=' . $page_parent_id . '&echo=0');
+} else {
+	$children = '';
+}
+
+/*
+ * Commented out until we're sure of what we want to do with attachments
+$attachments = get_posts( array(
+	'post_type' => 'attachment',
+	'posts_per_page' => -1,
+	'post_parent' => $page_parent_id,
+	'exclude'     => get_post_thumbnail_id( $page_parent_id ), //don't get the featured image
+) );
+*/
+?>
+<nav class="guide-nav span3">
+	<!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+	<div class="container clearfix">
+		<a class="btn btn-navbar toggle-nav-bar" title="More">
+			<div class="bars">
+				<span class="icon-bar"></span>
+				<span class="icon-bar"></span>
+				<span class="icon-bar"></span>
+			</div>
+		</a>
+
+		<?php if ( ! empty( $children ) ) { ?>
+			<?php if ( $top_page ) { ?>
+				<h4 class="guide-top">
+					<?php esc_html_e( 'In This ' . ucfirst( rtrim( $page_type, 's') ), 'cjet' ); ?>
+				</h4>
+			<?php } else { ?>
+				<h4 class="guide-top">
+					<a href="<?php echo esc_attr( get_permalink( $page_parent_id ) ); ?>">
+						<?php echo get_the_title( $page_parent_id ); ?>
+					</a>
+				</h4>
+			<?php } ?>
+		<?php } ?>
+
+		<ul class="guide-tree">
+			<?php echo $children; ?>
+
+			<?php dynamic_sidebar( 'guide-sidebar-below-toc' ); ?>
+		</ul>
+
+		<?php
+		/*
+		 * Commented out until we're sure of what we want to do with attachments
+		// on interior guide pages, list resources attached to the parent guide page
+		// if ( $attachments ) : ?>
+		<!-- <div class="resources">
+			<h4><?php _e('Related Resources', 'cjet'); ?></h4>
+			<ul class="guide-resources"><?php
+				// foreach ( $attachments as $attachment ) {
+				// 	//print_r( $attachment );
+				// 	$class = "mime-" . sanitize_title( $attachment->post_mime_type );
+				// 	echo '<li class="' . $class . ' data-design-thumbnail">';
+				// 	echo cjet_format_attachment_link( $attachment->ID );
+				// 	echo '</li>';
+				// }
+			?> -->
+			<!-- </ul></div> -->
+				<?php
+		// endif;	// resources links
+
+		*/
+		?>
+	</div>
+</nav>
+


### PR DESCRIPTION
## Changes

From https://github.com/INN/umbrella-inndev/issues/85#issuecomment-498721325 :
- [x] remove attachments code from article template
- [x] add Guide sidebar to article template
- [x] verify that sidebar is now same in code in guide/article templates
- [x] put that sidebar code into a partial, to deduplicate code and improve maintainability
- [x] see if there's a way to make no menu listing if post has no parent and has no children

Other items:

- Update description of Guide sidebar widget area in admin to make it clearer that this widget area is used on the Article and Guide templates
- When a widget is the first item in the sidebar, removes margin-top on the widget so it's at the very top of the sidebar: 
    <img width="544" alt="Screen Shot 2019-06-04 at 12 50 52 " src="https://user-images.githubusercontent.com/1754187/58897888-67d2e880-86c7-11e9-9563-ba5a28d4e545.png">

Resolves #85.