### PR TITLE
Simplify startup guide parent page logic

### DIFF
--- a/wp-content/themes/cjet/articles.php
+++ b/wp-content/themes/cjet/articles.php
@@ -45,7 +45,7 @@ $top_page = FALSE;
 					// we can leverage Largo's author info widget here
 
 						if ( $top_page ) {
-							$author_label = '<h3 class="widgettitle guide-author">' . __( 'Guide Author', 'cjet' ) . '</h3>';
+							$author_label = '<h3 class="widgettitle guide-author">' . __( 'Article Author', 'cjet' ) . '</h3>';
 						}
 
 						if ( $top_page && ( get_post_meta( $post->ID, 'cjet_hide_author', TRUE ) !== '1' ) ) {

--- a/wp-content/themes/cjet/articles.php
+++ b/wp-content/themes/cjet/articles.php
@@ -13,17 +13,15 @@ $top_page = FALSE;
 			// get the ID of the main page for a given article
 			$this_page_id = $post->ID;
 			$ancestors = get_post_ancestors( $this_page_id );
-			$page_type_id = end($ancestors); // the topmost parent is actually the "articles" page so let's back it up one
-			$page_type = get_post( $page_type_id )->post_name;
 
-			// in the future, it may make sense to make this === into <=
-			if ( count($ancestors) === 1 ) {
+			if ( count( $ancestors ) < 1 ) {
 				// this is the main page of the article so we can just list all of its children
 				$top_page = TRUE;
 				$page_parent_id = $post->ID;
 			} else {
 				// it's not and we need to do get the full page tree
-				$page_parent_id = prev($ancestors); // much better
+				// https://developer.wordpress.org/reference/functions/get_post_ancestors/ returns post IDs in order from child to parent
+				$page_parent_id = end($ancestors);
 			}
 
 			?>
@@ -46,9 +44,7 @@ $top_page = FALSE;
 					// if we're on a article "top" page, show author information and whatnot
 					// we can leverage Largo's author info widget here
 
-						if ( $top_page && $page_type == 'courses' ) {
-							echo '<h3 class="widgettitle guide-author">' . __( 'Course Instructor', 'cjet' ) . '</h3>';
-						} elseif ( $top_page ) {
+						if ( $top_page ) {
 							$author_label = '<h3 class="widgettitle guide-author">' . __( 'Guide Author', 'cjet' ) . '</h3>';
 						}
 

--- a/wp-content/themes/cjet/guides.php
+++ b/wp-content/themes/cjet/guides.php
@@ -13,16 +13,15 @@ $top_page = FALSE;
 			// get the ID of the main page for a given guide
 			$this_page_id = $post->ID;
 			$ancestors = get_post_ancestors( $this_page_id );
-			$page_type_id = end($ancestors); // the topmost parent is actually the "guides" page so let's back it up one
-			$page_type = get_post( $page_type_id )->post_name;
 
-			if ( count($ancestors) === 1 ) {
+			if ( count( $ancestors ) < 1 ) {
 				// this is the main page of the guide so we can just list all of its children
 				$top_page = TRUE;
 				$page_parent_id = $post->ID;
 			} else {
 				// it's not and we need to do get the full page tree
-				$page_parent_id = prev($ancestors); // much better
+				// https://developer.wordpress.org/reference/functions/get_post_ancestors/ returns post IDs in order from child to parent
+				$page_parent_id = end($ancestors);
 			}
 
 			?>
@@ -45,9 +44,7 @@ $top_page = FALSE;
 					// if we're on a guide "top" page, show author information and whatnot
 					// we can leverage Largo's author info widget here
 
-						if ( $top_page && $page_type == 'courses' ) {
-							echo '<h3 class="widgettitle guide-author">' . __( 'Course Instructor', 'cjet' ) . '</h3>';
-						} elseif ( $top_page ) {
+						if ( $top_page ) {
 							$author_label = '<h3 class="widgettitle guide-author">' . __( 'Guide Author', 'cjet' ) . '</h3>';
 						}
 

--- a/wp-content/themes/cjet/partials/nav-guide-footer.php
+++ b/wp-content/themes/cjet/partials/nav-guide-footer.php
@@ -27,15 +27,10 @@
 	}
 
 	if ( $top_page ) {
-		if ( $page_type == 'courses' ) {
-			$link_text = __('Get Started', 'cjet');
-		} else {
-			$link_text = __('Start Reading', 'cjet');
-		}
 		printf(
 			'<div class="next"><a href="%1$s" rel="next"><i class="dashicons dashicons-arrow-right-alt"></i><span class="meta-nav">%2$s</span></a></div>',
 			get_permalink( $next_id ),
-			$link_text
+			__('Start Reading', 'cjet')
 		);
 	} else {
 		if (!empty($prev_id)) {

--- a/wp-content/themes/cjet/partials/nav-guide-sidebar.php
+++ b/wp-content/themes/cjet/partials/nav-guide-sidebar.php
@@ -5,7 +5,6 @@
  * Expects the following variables to be defined:
  *
  * @param Int|Bool $page_parent_id The parent page of the current Guide
- * @param String $page_type The type of page it is?
  */
 
 // now get the complete tree of child pages for the guide's top page
@@ -39,7 +38,7 @@ $attachments = get_posts( array(
 		<?php if ( ! empty( $children ) ) { ?>
 			<?php if ( $top_page ) { ?>
 				<h4 class="guide-top">
-					<?php esc_html_e( 'In This ' . ucfirst( rtrim( $page_type, 's') ), 'cjet' ); ?>
+					<?php esc_html_e( 'In This Guide', 'cjet' ); ?>
 				</h4>
 			<?php } else { ?>
 				<h4 class="guide-top">


### PR DESCRIPTION
## Changes

- Removes the assumption that guides would be under a parent page titled "guides" in order to be a "top page"
- Removes code that supported the Courses section of content, as that is planned to be archived in the upcoming refresh.

Fixes #96.