### PR TITLE
101 change cjet theme name

### DIFF
--- a/wp-content/themes/README.md
+++ b/wp-content/themes/README.md
@@ -1,6 +1,6 @@
 # Explanation of themes:
 
-- cjet: learn.inn.org
+- cjet: learn.inn.org (formerly Community Journalism Executive Training)
 - impaq: impaq.inn.org, site no longer active but still online
 - **inn**: submodule at [INN/inn](https://github.com/INN/inn) for inn.org; has common stylesheets imported by these child themes
 - journobiz: innovation.inn.org

--- a/wp-content/themes/cjet/README.md
+++ b/wp-content/themes/cjet/README.md
@@ -1,0 +1,11 @@
+INN Learn WordPress Theme
+===
+
+This is the WordPress child theme used for https://learn.inn.org.
+
+The user-facing name of the theme is `INN Learn`, but all of the theme internals and functions are still under the orignal name `cjet` (Community Journalism Executive Training).
+
+As this is a child theme, it depends on the Largo parent theme which you can grab from: https://github.com/INN/Largo.
+
+If you're not familiar with how parent and child themes work, check out: http://codex.wordpress.org/Child_Themes.
+

--- a/wp-content/themes/cjet/functions.php
+++ b/wp-content/themes/cjet/functions.php
@@ -54,7 +54,7 @@ add_action( 'init', 'cjet_init' );
 function cjet_theme_options( $options ) {
 
 	$options[] = array(
-		'name' 	=> __('CJET', 'cjet'),
+		'name' 	=> __('INN Learn', 'cjet'),
 		'type' 	=> 'heading');
 
 	$options[] = array(

--- a/wp-content/themes/cjet/homepages/homepage.php
+++ b/wp-content/themes/cjet/homepages/homepage.php
@@ -3,8 +3,8 @@
 include_once get_template_directory() . '/homepages/homepage-class.php';
 
 class CJETHomepageLayout extends Homepage {
-	var $name = 'CJET/Newstraining.org Homepage Layout';
-	var $description = 'Custom homepage layout for Newstraining.org.';
+	var $name = 'learn.inn.org Homepage Layout';
+	var $description = 'Custom homepage layout for learn.inn.org.';
 
 	function __construct( $options=array() ) {
 		$defaults = array(

--- a/wp-content/themes/cjet/style.css
+++ b/wp-content/themes/cjet/style.css
@@ -1,9 +1,10 @@
 /*
-Theme Name:     Community Journalism Executive Training (CJET) (learn.inn.org)
+Theme Name:     INN Learn (learn.inn.org)
 Theme URI:      http://learn.inn.org
 Description:    A child theme for CJET, a program of the Institute for Nonprofit News
 Author:         The INN Nerds
 Author URI:     http://nerds.inn.org
+Text Domain:    cjet
 Template:       largo
 Version:        0.2.1
 */

--- a/wp-content/themes/cjet/style.css
+++ b/wp-content/themes/cjet/style.css
@@ -1,9 +1,9 @@
 /*
 Theme Name:     INN Learn (learn.inn.org)
 Theme URI:      http://learn.inn.org
-Description:    A child theme for CJET, a program of the Institute for Nonprofit News
-Author:         The INN Nerds
-Author URI:     http://nerds.inn.org
+Description:    A child theme for INN LEARN, a program of the Institute for Nonprofit News
+Author:         INN Labs
+Author URI:     https://labs.inn.org
 Text Domain:    cjet
 Template:       largo
 Version:        0.2.1


### PR DESCRIPTION
Everything from #105, but merging into staging instead of master. Oops.

## Changes

This pull request makes the following changes:

- Updated the `cjet` theme name to `INN Learn` in `style.css` so users aren't confused when viewing the active theme in the admin panel.
- Added a basic readme to the `cjet` theme directory.

Before:
![Screen Shot 2019-07-11 at 1 45 41 PM](https://user-images.githubusercontent.com/18353636/61073047-8de45a80-a3e2-11e9-8c58-ad5e3fbc5d92.png)

After:
![Screen Shot 2019-07-11 at 1 45 30 PM](https://user-images.githubusercontent.com/18353636/61073048-8de45a80-a3e2-11e9-8a11-9b652a630538.png)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #101 / #104

## Testing/Questions

Features that this PR affects:

- `cjet` theme

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is `INN Learn` an acceptable name?
- [x] Should it be updated anywhere else?

Steps to test this PR:

1. View the Learn site themes page and make sure the active theme says `INN Learn` instead of `Community Journalism Executive Training`.
2. Make sure nothing is broken.