### PR TITLE
Bump Largo version number to 0.6.4

### DIFF
--- a/wp-content/themes/largoproject/homepages/templates/largo.php
+++ b/wp-content/themes/largoproject/homepages/templates/largo.php
@@ -3,7 +3,7 @@
 		<div id="logo-and-description" class="clearfix">
 			<div id="hero-logo">
 				<img src="<?php echo get_stylesheet_directory_uri(); ?>/homepages/assets/img/logos/largo-project-logo.svg" />
-				<span id="version">Version 0.6.1<span>
+				<span id="version">Version 0.6.4<span>
 			</div>
 			<div id="hero-description">
 				<h4>The WordPress Framework for News Websites</h4>

--- a/wp-content/themes/largoproject/partials/largo-hero.php
+++ b/wp-content/themes/largoproject/partials/largo-hero.php
@@ -4,7 +4,7 @@
 <div class="site-hero">
 	<img src="<?php echo get_stylesheet_directory_uri(); ?>/img/largo-sq.png" />
 	<h3 class="tagline">The WordPress Framework for News Websites</h3>
-	<a class="btn" href="https://github.com/INN/largo/releases/tag/v0.6.1">Download Largo</a>
-	<p class="version">Version 0.6.1</p>
+	<a class="btn" href="https://github.com/INN/largo/releases/tag/v0.6.4">Download Largo</a>
+	<p class="version">Version 0.6.4</p>
 </div>
 <?php }


### PR DESCRIPTION
## Changes

- Updates the Largo version number in the `largoproject` theme to the newest release, `0.6.4`.

## Why

To keep the site up to date with the latest release.