### PR TITLE
Add missing mu-plugin that changes the uploads folder to be the same folder for all blogs.

### DIFF
--- a/wp-content/mu-plugins/change-upload-paths.php
+++ b/wp-content/mu-plugins/change-upload-paths.php
@@ -1,0 +1,22 @@
+<?php
+/*
+  Plugin Name: Change Uploads Paths
+  Plugin URI: http://investigativenewsnetwork.org
+  Description: Use the main uploads folder for all blogs
+  Author: Adam Schweigert
+  Version: 0.1
+ */
+
+add_filter('upload_dir', 'ms_global_upload_dir');
+
+function ms_global_upload_dir($uploads)
+{
+    $ms_dir = '/sites/' . get_current_blog_id();
+
+    $uploads['path']    = str_replace($ms_dir, "", $uploads['path']);
+    $uploads['url']     = str_replace($ms_dir, "", $uploads['url']);
+    $uploads['basedir'] = str_replace($ms_dir, "", $uploads['basedir']);
+    $uploads['baseurl'] = str_replace($ms_dir, "", $uploads['baseurl']);
+
+    return $uploads;
+}


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds to Git a file already present and active on inn.org, inndev.staging.wpengine.com, and inndevlearn.wpengine.com

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
Discovered in the course of working on https://github.com/INN/umbrella-inndev/issues/118 that localhost had different upload paths than any staging site. Adding this file will ensure that, when cloning, our local cloned sites will match the expected production configurations.

## Testing/Questions

Features that this PR affects:

- upload paths on localhost; prod remains unaffected by this PR because the file is already present in the mu-plugins dir.

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [x] Is any review needed before merging, if the code is already live and has been live for the last _unknown time span_? (Probably since 2014-2015, when inndev became the main INN site?)

Steps to test this PR:

1. Check out the PR — no configuration is necessary because this plugin's presence in the `mu-plugins` dir will cause it to be automatically activated.

## Additional information

Code was originally written by @aschweigert, director of INN Nerds at the time.