### PR TITLE
Embed feed base template

### DIFF
--- a/wp-content/themes/amplify/amplify-feed.php
+++ b/wp-content/themes/amplify/amplify-feed.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Single Post Template: Amplify Feed
+ * Template Name: Amplify Feed Template
+ * Description: Shows the saved links feed that can be embedded on external sites.
+ */
+
+?>
+
+<img src="http://placehold.it/200x200">
+<h2>Lens on Lightfoot</h2>
+<a href="https://inn.org/amplify" target="_blank">Learn More</a>
+
+<?php
+
+$query_args = array (
+    'post__not_in' => get_option( 'sticky_posts' ),
+    'showposts'    => $instance['num_posts'],
+    'post_type'    => 'rounduplink',
+    'tax_query' => array(
+        array (
+            'taxonomy' => 'lr-tags',
+            'field' => 'slug',
+            'terms' => 'lens-on-lightfoot',
+        )
+    ),
+    'post_status'  => 'publish'
+);
+$my_query = new WP_Query( $query_args );
+
+if ( $my_query->have_posts() ) {
+
+    echo '<h3>Stories from the Project</h3>';
+
+    while ( $my_query->have_posts() ) : $my_query->the_post();
+    $saved_link = get_post_custom( $post->ID );
+
+    // skip roundups
+    if ( get_post_type( $post ) === 'roundup' ) continue; ?>
+
+    <div class="saved-link clearfix">
+        <h5><?php
+            if ( isset( $saved_link["lr_url"][0] ) ) {
+                $output = '<a href="' . $saved_link["lr_url"][0] . '" ';
+                $output .= 'target="_blank" ';
+                $output .= '>' . get_the_title() . '</a>';
+            } else {
+                $output = get_the_title();
+            }
+            echo $output;
+            ?>
+        </h5>
+
+        <?php
+            if ( isset($saved_link["lr_source"][0] ) && !empty( $saved_link["lr_source"][0] ) ) {
+                $saved_link_source = '<p class="source">' . __('By: ', 'link-roundups') . '<span>';
+                if ( !empty( $saved_link["lr_url"][0] ) ) {
+                    $saved_link_source .= '<a href="' . $saved_link["lr_url"][0] . '" ';
+                    $saved_link_source .= 'target="_blank" ';
+                    $saved_link_source .= '>' . $saved_link["lr_source"][0] . '</a>';
+                } else {
+                    $saved_link_source .= $saved_link["lr_source"][0];
+                }
+                $saved_link_source .= '</span></p>';
+                echo $saved_link_source;
+            }
+            if ( isset( $saved_link["lr_desc"][0] ) ) {
+                echo '<div class="description">';
+                    echo $saved_link["lr_desc"][0];
+                echo '</div>';
+            }
+        ?>
+    </div> <!-- /.post-lead -->
+    
+<?php
+    endwhile;
+} else {
+    _e( '<p class="error">You don\'t have any recent links or the link roundups plugin is not active.</p>', 'link-roundups' );
+} // end recent links

--- a/wp-content/themes/amplify/amplify-feed.php
+++ b/wp-content/themes/amplify/amplify-feed.php
@@ -16,6 +16,10 @@
 	<meta charset="<?php bloginfo( 'charset' ); ?>" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <link rel="profile" href="https://gmpg.org/xfn/11" />
+    <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />
+    <title>Amplify Embed Feed | INN Amplify Project</title>
+    <?php wp_head(); ?>
 </head>
 <body>
 

--- a/wp-content/themes/amplify/amplify-feed.php
+++ b/wp-content/themes/amplify/amplify-feed.php
@@ -4,76 +4,110 @@
  * Template Name: Amplify Feed Template
  * Description: Shows the saved links feed that can be embedded on external sites.
  */
-
 ?>
 
-<img src="http://placehold.it/200x200">
-<h2>Lens on Lightfoot</h2>
-<a href="https://inn.org/amplify" target="_blank">Learn More</a>
+<div class="amplify-embed-feed">
 
-<?php
+    <?php
 
-$query_args = array (
-    'post__not_in' => get_option( 'sticky_posts' ),
-    'showposts'    => $instance['num_posts'],
-    'post_type'    => 'rounduplink',
-    'tax_query' => array(
-        array (
+    if( isset( $_GET['tag'] ) ){
+        
+        $term = $_GET['tag'];
+        $term = get_term_by( 'slug', $term, 'lr-tags' );
+
+        $term_more_link = get_term_link( $term, 'lr-tags' );
+        
+        if ( function_exists ( 'largo_get_term_meta_post' ) ) {
+            
+            $term_meta_post = largo_get_term_meta_post( 'lr-tags', $term->term_id );
+            $term_meta = get_post_meta( $term_meta_post );
+
+            if( $term_meta['lr_more_link'] ){
+                $term_more_link = $term_meta['lr_more_link'][0];
+            }
+
+            $thumbnail = get_the_post_thumbnail_url( $term->term_id, 'large' );
+            echo '<img src="'.$thumbnail.'">';
+
+        }
+        ?>
+        <h2><?php echo $term->name; ?></h2>
+        <p><?php echo $term->description; ?></p>
+        <a href="<?php echo $term_more_link; ?>" target="_blank">Learn More</a>
+        <?php
+    }
+
+    $query_args = array (
+        'post__not_in' => get_option( 'sticky_posts' ),
+        'showposts'    => $instance['num_posts'],
+        'post_type'    => 'rounduplink',
+        'post_status'  => 'publish'
+    );
+
+    if( $term ){
+
+        $tax_query = array (
             'taxonomy' => 'lr-tags',
             'field' => 'slug',
-            'terms' => 'lens-on-lightfoot',
-        )
-    ),
-    'post_status'  => 'publish'
-);
-$my_query = new WP_Query( $query_args );
+            'terms' => $term->slug,
+        );
 
-if ( $my_query->have_posts() ) {
+        $query_args['tax_query'] = array( $tax_query );
 
-    echo '<h3>Stories from the Project</h3>';
+    }
 
-    while ( $my_query->have_posts() ) : $my_query->the_post();
-    $saved_link = get_post_custom( $post->ID );
+    $my_query = new WP_Query( $query_args );
 
-    // skip roundups
-    if ( get_post_type( $post ) === 'roundup' ) continue; ?>
+    if ( $my_query->have_posts() ) {
 
-    <div class="saved-link clearfix">
-        <h5><?php
-            if ( isset( $saved_link["lr_url"][0] ) ) {
-                $output = '<a href="' . $saved_link["lr_url"][0] . '" ';
-                $output .= 'target="_blank" ';
-                $output .= '>' . get_the_title() . '</a>';
-            } else {
-                $output = get_the_title();
-            }
-            echo $output;
-            ?>
-        </h5>
+        echo '<h3>Stories from the Project</h3>';
 
-        <?php
-            if ( isset($saved_link["lr_source"][0] ) && !empty( $saved_link["lr_source"][0] ) ) {
-                $saved_link_source = '<p class="source">' . __('By: ', 'link-roundups') . '<span>';
-                if ( !empty( $saved_link["lr_url"][0] ) ) {
-                    $saved_link_source .= '<a href="' . $saved_link["lr_url"][0] . '" ';
-                    $saved_link_source .= 'target="_blank" ';
-                    $saved_link_source .= '>' . $saved_link["lr_source"][0] . '</a>';
+        while ( $my_query->have_posts() ) : $my_query->the_post();
+        $saved_link = get_post_custom( $post->ID );
+
+        // skip roundups
+        if ( get_post_type( $post ) === 'roundup' ) continue; ?>
+
+        <div class="saved-link clearfix">
+            <h5><?php
+                if ( isset( $saved_link["lr_url"][0] ) ) {
+                    $output = '<a href="' . $saved_link["lr_url"][0] . '" ';
+                    $output .= 'target="_blank" ';
+                    $output .= '>' . get_the_title() . '</a>';
                 } else {
-                    $saved_link_source .= $saved_link["lr_source"][0];
+                    $output = get_the_title();
                 }
-                $saved_link_source .= '</span></p>';
-                echo $saved_link_source;
-            }
-            if ( isset( $saved_link["lr_desc"][0] ) ) {
-                echo '<div class="description">';
-                    echo $saved_link["lr_desc"][0];
-                echo '</div>';
-            }
-        ?>
-    </div> <!-- /.post-lead -->
-    
-<?php
-    endwhile;
-} else {
-    _e( '<p class="error">You don\'t have any recent links or the link roundups plugin is not active.</p>', 'link-roundups' );
-} // end recent links
+                echo $output;
+                ?>
+            </h5>
+
+            <?php
+                if ( isset($saved_link["lr_source"][0] ) && !empty( $saved_link["lr_source"][0] ) ) {
+                    $saved_link_source = '<p class="source">' . __('By: ', 'link-roundups') . '<span>';
+                    if ( !empty( $saved_link["lr_url"][0] ) ) {
+                        $saved_link_source .= '<a href="' . $saved_link["lr_url"][0] . '" ';
+                        $saved_link_source .= 'target="_blank" ';
+                        $saved_link_source .= '>' . $saved_link["lr_source"][0] . '</a>';
+                    } else {
+                        $saved_link_source .= $saved_link["lr_source"][0];
+                    }
+                    $saved_link_source .= '</span></p>';
+                    echo $saved_link_source;
+                }
+                if ( isset( $saved_link["lr_desc"][0] ) ) {
+                    echo '<div class="description">';
+                        echo $saved_link["lr_desc"][0];
+                    echo '</div>';
+                }
+            ?>
+        </div>
+        
+    <?php
+        endwhile;
+    } else {
+        _e( '<p class="error">You don\'t have any recent links or the link roundups plugin is not active.</p>', 'link-roundups' );
+    } // end recent links
+
+    ?>
+
+</div>

--- a/wp-content/themes/amplify/amplify-feed.php
+++ b/wp-content/themes/amplify/amplify-feed.php
@@ -6,108 +6,123 @@
  */
 ?>
 
-<div class="amplify-embed-feed">
+<!DOCTYPE html>
+<!--[if lt IE 7]> <html <?php language_attributes(); ?> class="no-js ie6"> <![endif]-->
+<!--[if IE 7]>    <html <?php language_attributes(); ?> class="no-js ie7"> <![endif]-->
+<!--[if IE 8]>    <html <?php language_attributes(); ?> class="no-js ie8"> <![endif]-->
+<!--[if IE 9]>    <html <?php language_attributes(); ?> class="no-js ie9"> <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--> <html <?php language_attributes(); ?> class="no-js"> <!--<![endif]-->
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+</head>
+<body>
 
-    <?php
+    <div class="amplify-embed-feed">
 
-    if( isset( $_GET['tag'] ) ){
-        
-        $term = $_GET['tag'];
-        $term = get_term_by( 'slug', $term, 'lr-tags' );
-
-        $term_more_link = get_term_link( $term, 'lr-tags' );
-        
-        if ( function_exists ( 'largo_get_term_meta_post' ) ) {
-            
-            $term_meta_post = largo_get_term_meta_post( 'lr-tags', $term->term_id );
-            $term_meta = get_post_meta( $term_meta_post );
-
-            if( $term_meta['lr_more_link'] ){
-                $term_more_link = $term_meta['lr_more_link'][0];
-            }
-
-            $thumbnail = get_the_post_thumbnail_url( $term->term_id, 'large' );
-            echo '<img src="'.$thumbnail.'">';
-
-        }
-        ?>
-        <h2><?php echo $term->name; ?></h2>
-        <p><?php echo $term->description; ?></p>
-        <a href="<?php echo $term_more_link; ?>" target="_blank">Learn More</a>
         <?php
-    }
 
-    $query_args = array (
-        'post__not_in' => get_option( 'sticky_posts' ),
-        'showposts'    => $instance['num_posts'],
-        'post_type'    => 'rounduplink',
-        'post_status'  => 'publish'
-    );
+        if( isset( $_GET['tag'] ) ){
+            
+            $term = $_GET['tag'];
+            $term = get_term_by( 'slug', $term, 'lr-tags' );
+            
+            if ( function_exists ( 'largo_get_term_meta_post' ) ) {
+                
+                $term_meta_post = largo_get_term_meta_post( 'lr-tags', $term->term_id );
+                $term_meta = get_post_meta( $term_meta_post );
 
-    if( $term ){
-
-        $tax_query = array (
-            'taxonomy' => 'lr-tags',
-            'field' => 'slug',
-            'terms' => $term->slug,
-        );
-
-        $query_args['tax_query'] = array( $tax_query );
-
-    }
-
-    $my_query = new WP_Query( $query_args );
-
-    if ( $my_query->have_posts() ) {
-
-        echo '<h3>Stories from the Project</h3>';
-
-        while ( $my_query->have_posts() ) : $my_query->the_post();
-        $saved_link = get_post_custom( $post->ID );
-
-        // skip roundups
-        if ( get_post_type( $post ) === 'roundup' ) continue; ?>
-
-        <div class="saved-link clearfix">
-            <h5><?php
-                if ( isset( $saved_link["lr_url"][0] ) ) {
-                    $output = '<a href="' . $saved_link["lr_url"][0] . '" ';
-                    $output .= 'target="_blank" ';
-                    $output .= '>' . get_the_title() . '</a>';
-                } else {
-                    $output = get_the_title();
+                if( $term_meta['lr_more_link'] ){
+                    $term_more_link = $term_meta['lr_more_link'][0];
                 }
-                echo $output;
-                ?>
-            </h5>
 
+                $thumbnail = get_the_post_thumbnail_url( $term_meta_post, 'large' );
+                echo '<img src="'.$thumbnail.'">';
+
+            }
+            ?>
+            <h2><?php echo $term->name; ?></h2>
+            <p><?php echo $term->description; ?></p>
             <?php
-                if ( isset($saved_link["lr_source"][0] ) && !empty( $saved_link["lr_source"][0] ) ) {
-                    $saved_link_source = '<p class="source">' . __('By: ', 'link-roundups') . '<span>';
-                    if ( !empty( $saved_link["lr_url"][0] ) ) {
-                        $saved_link_source .= '<a href="' . $saved_link["lr_url"][0] . '" ';
-                        $saved_link_source .= 'target="_blank" ';
-                        $saved_link_source .= '>' . $saved_link["lr_source"][0] . '</a>';
-                    } else {
-                        $saved_link_source .= $saved_link["lr_source"][0];
-                    }
-                    $saved_link_source .= '</span></p>';
-                    echo $saved_link_source;
-                }
-                if ( isset( $saved_link["lr_desc"][0] ) ) {
-                    echo '<div class="description">';
-                        echo $saved_link["lr_desc"][0];
-                    echo '</div>';
+                if( $term_more_link ){
+                    echo '<a href="'.$term_more_link.'" target="_blank">Learn More</a>';
                 }
             ?>
-        </div>
-        
-    <?php
-        endwhile;
-    } else {
-        _e( '<p class="error">You don\'t have any recent links or the link roundups plugin is not active.</p>', 'link-roundups' );
-    } // end recent links
+            <?php
+        }
 
-    ?>
+        $query_args = array (
+            'post_type'    => 'rounduplink',
+            'post_status'  => 'publish'
+        );
 
-</div>
+        if( $term ){
+
+            $tax_query = array (
+                'taxonomy' => 'lr-tags',
+                'field' => 'slug',
+                'terms' => $term->slug,
+            );
+
+            $query_args['tax_query'] = array( $tax_query );
+
+        }
+
+        $my_query = new WP_Query( $query_args );
+
+        if ( $my_query->have_posts() ) {
+
+            echo '<h3>Stories from the Project</h3>';
+
+            while ( $my_query->have_posts() ) : $my_query->the_post();
+            $saved_link = get_post_custom( $post->ID );
+
+            // skip roundups
+            if ( get_post_type( $post ) === 'roundup' ) continue; ?>
+
+            <div class="saved-link clearfix">
+                <h5><?php
+                    if ( isset( $saved_link["lr_url"][0] ) ) {
+                        $output = '<a href="' . $saved_link["lr_url"][0] . '" ';
+                        $output .= 'target="_blank" ';
+                        $output .= '>' . get_the_title() . '</a>';
+                    } else {
+                        $output = get_the_title();
+                    }
+                    echo $output;
+                    ?>
+                </h5>
+
+                <?php
+                    if ( isset($saved_link["lr_source"][0] ) && !empty( $saved_link["lr_source"][0] ) ) {
+                        $saved_link_source = '<p class="source">' . __('By: ', 'link-roundups') . '<span>';
+                        if ( !empty( $saved_link["lr_url"][0] ) ) {
+                            $saved_link_source .= '<a href="' . $saved_link["lr_url"][0] . '" ';
+                            $saved_link_source .= 'target="_blank" ';
+                            $saved_link_source .= '>' . $saved_link["lr_source"][0] . '</a>';
+                        } else {
+                            $saved_link_source .= $saved_link["lr_source"][0];
+                        }
+                        $saved_link_source .= '</span></p>';
+                        echo $saved_link_source;
+                    }
+                    if ( isset( $saved_link["lr_desc"][0] ) ) {
+                        echo '<div class="description">';
+                            echo $saved_link["lr_desc"][0];
+                        echo '</div>';
+                    }
+                ?>
+            </div>
+            
+        <?php
+            endwhile;
+        } else {
+            _e( '<p class="error">You don\'t have any recent links or the link roundups plugin is not active.</p>', 'link-roundups' );
+        } // end recent links
+
+        ?>
+
+    </div>
+</body>
+</html>

--- a/wp-content/themes/amplify/amplify-feed.php
+++ b/wp-content/themes/amplify/amplify-feed.php
@@ -37,7 +37,7 @@
                 $term_meta_post = largo_get_term_meta_post( 'lr-tags', $term->term_id );
                 $term_meta = get_post_meta( $term_meta_post );
 
-                if( $term_meta['lr_more_link'] ){
+                if ( ! empty( trim( $term_meta['lr_more_link'][0] ) ) ) {
                     $term_more_link = $term_meta['lr_more_link'][0];
                 }
 

--- a/wp-content/themes/amplify/functions.php
+++ b/wp-content/themes/amplify/functions.php
@@ -84,3 +84,52 @@ function amplify_load_feed_template( $template ) {
 	
 }
 add_filter( 'template_include', 'amplify_load_feed_template' );
+
+/**
+ * Add the "More link" input field to the tag edit page for 'lr-tags' taxonomy
+ * 
+ * @param obj $context The wp term that is being modified
+ */
+function amplify_add_saved_link_roundups_more_link_metabox( $context = '' ) {
+
+	if( 'lr-tags' == $context->taxonomy ){
+		
+		$term_more_link = get_term_link( $context, $context->taxonomy );
+
+		// Post ID here is the id of the post that Largo uses to keep track of the term's metadata. See largo_get_term_meta_post.
+		$post_id = largo_get_term_meta_post( $context->taxonomy, $context->term_id );
+
+		if( metadata_exists( 'post', $post_id, 'lr_more_link' ) ) {
+			$term_more_link = get_post_meta( $post_id, 'lr_more_link', true );
+		}
+
+		?>
+		<tr class="form-field">
+			<th scope="row" valign="top"><?php _e('More link', 'amplify'); ?></th>
+			<td>
+				<input class="widefat" id="more_link" name="lr_more_link" type="url" value="<?php echo $term_more_link; ?>" />
+				<p class="description">If the "More" link that is displayed needs to redirect to somewhere other than the tag archive page, change it here.</p>
+			</td>
+		</tr>
+		<?php
+
+	}
+
+}
+add_action( 'edit_tag_form_fields', 'amplify_add_saved_link_roundups_more_link_metabox');
+
+/**
+ * Function to save specific meta for LR tags	
+ */
+function save_lr_tag_meta( $term_id ) {
+
+	// we'll need to get the post id of the term that Largo uses to keep track of its meta. See largo_get_term_meta_post.
+	$post_id = largo_get_term_meta_post( 'lr-tags', $term_id );
+
+	// save the "More" link meta if posible
+	if( isset( $_POST['lr_more_link'] ) && ! empty( $_POST['lr_more_link'] ) ) {
+		update_post_meta( $post_id, 'lr_more_link', sanitize_url( $_POST['lr_more_link'] ) );
+	}
+
+}
+add_action( 'edit_term', 'save_lr_tag_meta' );

--- a/wp-content/themes/amplify/functions.php
+++ b/wp-content/themes/amplify/functions.php
@@ -72,8 +72,8 @@ add_filter( 'query_vars', 'amplify_add_query_vars' );
 function amplify_load_feed_template( $template ) { 
 
     if ( ! is_admin() ) {
-        // if the params are set, use our amplify feed template
-		if( isset( $_GET['amplify-feed'] ) ){
+        // if the params are set, use our amplify feed template if it exists
+		if( isset( $_GET['amplify-feed'] ) && locate_template( 'amplify-feed.php' ) ){
 			return get_stylesheet_directory().'/amplify-feed.php';
 		// else, continue with whatever template was being loaded
 		} else {

--- a/wp-content/themes/amplify/functions.php
+++ b/wp-content/themes/amplify/functions.php
@@ -45,3 +45,42 @@ function largo_parent_theme_enqueue_styles() {
 	);
 }
 add_action( 'wp_enqueue_scripts', 'largo_parent_theme_enqueue_styles', 20 );
+
+/**
+ * Add query vars specific to the Amplify child theme
+ * 
+ * @param array $vars The array of available query vars
+ * 
+ * @return array $vars The modified array of available query vars
+ */
+function amplify_add_query_vars( $vars ) {
+	
+	$vars[] = 'amplify-feed';
+	
+	return $vars;
+
+}
+add_filter( 'query_vars', 'amplify_add_query_vars' );
+
+/**
+ * Load the Amplify embed feed template if specific query param is present
+ * 
+ * @param str $template The path of the current template
+ * 
+ * @return str $template The path of the template to include
+ */
+function amplify_load_feed_template( $template ) { 
+
+    if ( ! is_admin() ) {
+        // if the params are set, use our amplify feed template
+		if( isset( $_GET['amplify-feed'] ) ){
+			return get_stylesheet_directory().'/amplify-feed.php';
+		// else, continue with whatever template was being loaded
+		} else {
+			return $template;
+		}
+    }
+	return $template;
+	
+}
+add_filter( 'template_include', 'amplify_load_feed_template' );

--- a/wp-content/themes/amplify/functions.php
+++ b/wp-content/themes/amplify/functions.php
@@ -93,8 +93,8 @@ add_filter( 'template_include', 'amplify_load_feed_template' );
 function amplify_add_saved_link_roundups_more_link_metabox( $context = '' ) {
 
 	if( 'lr-tags' == $context->taxonomy ){
-		
-		$term_more_link = get_term_link( $context, $context->taxonomy );
+
+		$term_more_link = '';
 
 		// Post ID here is the id of the post that Largo uses to keep track of the term's metadata. See largo_get_term_meta_post.
 		$post_id = largo_get_term_meta_post( $context->taxonomy, $context->term_id );
@@ -108,7 +108,7 @@ function amplify_add_saved_link_roundups_more_link_metabox( $context = '' ) {
 			<th scope="row" valign="top"><?php _e('More link', 'amplify'); ?></th>
 			<td>
 				<input class="widefat" id="more_link" name="lr_more_link" type="url" value="<?php echo $term_more_link; ?>" />
-				<p class="description">If the "More" link that is displayed needs to redirect to somewhere other than the tag archive page, change it here.</p>
+				<p class="description"><?php _e( 'If the "More" link that is displayed needs to redirect to somewhere other than the tag archive page, change it here.', 'amplify' ); ?></p>
 			</td>
 		</tr>
 		<?php

--- a/wp-content/themes/amplify/functions.php
+++ b/wp-content/themes/amplify/functions.php
@@ -39,7 +39,7 @@ function largo_parent_theme_enqueue_styles() {
 
 	wp_enqueue_style( 'largo-style', get_template_directory_uri() . '/style.css' );
 	wp_enqueue_style( 'amplify-style',
-		get_stylesheet_directory_uri() . '/css/style.css',
+		get_stylesheet_directory_uri() . '/css/child-style.css',
 		array( 'largo-stylesheet' ),
 		filemtime( get_stylesheet_directory() . '/css/child-style.css' )
 	);


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds the `amplify-feed.php` template that displays saved links from the LR plugin.
   - Only shows if using the `amplify-feed` query param
   - Can be filtered to display only saved links by specific tag using the `tag` query parameter
      - If no specific tag param is set, it will show all saved links
      - Displays current tag title, featured image, description, and "Learn more link"
   - Currently no styling or anything to make it pretty
- Adds "More link" metabox to `lr-tags` taxonomy editor so we can specify what the "Learn More" should link to if we don't want it to link the the tag archive page

Very ugly example:
![screencapture-amplify-inndev-test-2019-12-11-12_59_19](https://user-images.githubusercontent.com/18353636/70647016-15462c00-1c16-11ea-8354-7880aeb71877.png)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #125 

## Testing/Questions

Features that this PR affects:

- Lens on lightfood embed template

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [ ] If no tag is specified, should there at least be some sort of generic title, link, description, and learn more button?

Steps to test this PR:

1. Add a few different `lr-tags` tags with descriptions, featured media, more links, etc.
2. Add some saved links via link roundups and add them to specific categories
3. View `local-site.test/?amplify-feed` and make sure all saved links display
4. View `local-site.test?amplify-feed&tag=YOUR_TAG_HERE` and make sure all saved links in that tag display