### PR TITLE
Dequeue unused styles scripts

### DIFF
--- a/wp-content/themes/amplify/functions.php
+++ b/wp-content/themes/amplify/functions.php
@@ -35,9 +35,33 @@ add_action( 'after_setup_theme', 'largo_child_require_files' );
  * Enqueue scripts and styles.
  */
 function largo_parent_theme_enqueue_styles() {
-	wp_dequeue_style( 'largo-child-styles' );
+
+	$dequeue_styles_list = array(
+		'largo-child-styles',
+		'wp-block-library',
+		'chosen',
+		'wp-job-manager-frontend',
+		'navis-slick',
+		'navis-slides',
+		'largo-stylesheet-gutenberg',
+		'link-roundups',
+	);
+
+	foreach( $dequeue_styles_list as $dequeue_style ){
+		wp_dequeue_style( $dequeue_style );
+	}
+
+	$dequeue_scripts_list = array(
+		'largo-modernizr',
+		'load-more-posts',
+	);
+
+	foreach( $dequeue_scripts_list as $dequeue_script ){
+		wp_dequeue_script( $dequeue_script );
+	}
 
 	wp_enqueue_style( 'largo-style', get_template_directory_uri() . '/style.css' );
+
 	wp_enqueue_style( 'amplify-style',
 		get_stylesheet_directory_uri() . '/css/child-style.css',
 		array( 'largo-stylesheet' ),

--- a/wp-content/themes/amplify/functions.php
+++ b/wp-content/themes/amplify/functions.php
@@ -56,11 +56,17 @@ function largo_parent_theme_enqueue_styles() {
 		$dequeue_scripts_list = array(
 			'largo-modernizr',
 			'load-more-posts',
+			'jquery',
+			'jquery-migrate',
 		);
 
 		foreach( $dequeue_scripts_list as $dequeue_script ){
-			wp_dequeue_script( $dequeue_script );
+			wp_deregister_script( $dequeue_script );
 		}
+
+		// remove emojis from head
+		remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
+		remove_action( 'wp_print_styles', 'print_emoji_styles' );
 
 	}
 
@@ -73,6 +79,13 @@ function largo_parent_theme_enqueue_styles() {
 	);
 }
 add_action( 'wp_enqueue_scripts', 'largo_parent_theme_enqueue_styles', 20 );
+
+function amplify_remove_largo_header_js() {
+	if( isset( $_GET['amplify-feed'] ) ){
+		remove_action( 'wp_enqueue_scripts', 'largo_header_js' );
+	}
+}
+add_action( 'wp_enqueue_scripts', 'amplify_remove_largo_header_js', 1 );
 
 /**
  * Add query vars specific to the Amplify child theme

--- a/wp-content/themes/amplify/functions.php
+++ b/wp-content/themes/amplify/functions.php
@@ -36,28 +36,32 @@ add_action( 'after_setup_theme', 'largo_child_require_files' );
  */
 function largo_parent_theme_enqueue_styles() {
 
-	$dequeue_styles_list = array(
-		'largo-child-styles',
-		'wp-block-library',
-		'chosen',
-		'wp-job-manager-frontend',
-		'navis-slick',
-		'navis-slides',
-		'largo-stylesheet-gutenberg',
-		'link-roundups',
-	);
+	if( isset( $_GET['amplify-feed'] ) ){
 
-	foreach( $dequeue_styles_list as $dequeue_style ){
-		wp_dequeue_style( $dequeue_style );
-	}
+		$dequeue_styles_list = array(
+			'largo-child-styles',
+			'wp-block-library',
+			'chosen',
+			'wp-job-manager-frontend',
+			'navis-slick',
+			'navis-slides',
+			'largo-stylesheet-gutenberg',
+			'link-roundups',
+		);
 
-	$dequeue_scripts_list = array(
-		'largo-modernizr',
-		'load-more-posts',
-	);
+		foreach( $dequeue_styles_list as $dequeue_style ){
+			wp_dequeue_style( $dequeue_style );
+		}
 
-	foreach( $dequeue_scripts_list as $dequeue_script ){
-		wp_dequeue_script( $dequeue_script );
+		$dequeue_scripts_list = array(
+			'largo-modernizr',
+			'load-more-posts',
+		);
+
+		foreach( $dequeue_scripts_list as $dequeue_script ){
+			wp_dequeue_script( $dequeue_script );
+		}
+
 	}
 
 	wp_enqueue_style( 'largo-style', get_template_directory_uri() . '/style.css' );


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Dequeues these stylesheets if the `amplify-feed` query param exists:
```
'largo-child-styles',
'wp-block-library',
'chosen',
'wp-job-manager-frontend',
'navis-slick',
'navis-slides',
'largo-stylesheet-gutenberg',
'link-roundups',
```

- Dequeues these scripts if the `amplify-feed` query param exists:
```
'largo-modernizr',
'load-more-posts',
```

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #132 

## Testing/Questions

Features that this PR affects:

- Amplify theme and embed template

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [ ] Are there any other scripts to dequeue?
- [ ] Are there any other stylesheets to dequeue?
- [ ] https://github.com/INN/umbrella-inndev/pull/133/commits/6ce22aaf3230dcae263991d47564e34a8bef4d8c wraps the dequeue functions in a conditional that only fires if the `amplify-feed` query param is set. Do you think that's necessary?

Steps to test this PR:

1. View the embed template
2. Make sure it's functioning as expected