### PR TITLE
Remove ':' from byline on feed template

### DIFF
--- a/wp-content/themes/amplify/amplify-feed.php
+++ b/wp-content/themes/amplify/amplify-feed.php
@@ -132,7 +132,7 @@ if( isset( $_GET['rows'] ) && 2 == $_GET['rows'] ){
 
                 <?php
                     if ( isset($saved_link["lr_source"][0] ) && !empty( $saved_link["lr_source"][0] ) ) {
-                        $saved_link_source = '<p class="source">' . __('By: ', 'link-roundups') . '<span>';
+                        $saved_link_source = '<p class="source">' . __('By ', 'link-roundups') . '<span>';
                         if ( !empty( $saved_link["lr_url"][0] ) ) {
                             $saved_link_source .= '<a href="' . $saved_link["lr_url"][0] . '" ';
                             $saved_link_source .= 'target="_blank" ';


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Removes the ':' from the byline so it starts with `By ` instead of `By: `

Before:
![Screen Shot 2020-01-03 at 11 44 21 AM](https://user-images.githubusercontent.com/18353636/71736230-8d230300-2e1e-11ea-89e4-fa9b978cf0f0.png)

After:
![Screen Shot 2020-01-03 at 11 44 44 AM](https://user-images.githubusercontent.com/18353636/71736229-8d230300-2e1e-11ea-8346-28d2bf82fb67.png)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #127 

## Testing/Questions

Features that this PR affects:

- Feed template byline

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?