### PR TITLE
learn.inn.org guide template sidebar updates

### DIFF
--- a/wp-content/themes/cjet/partials/nav-guide-sidebar.php
+++ b/wp-content/themes/cjet/partials/nav-guide-sidebar.php
@@ -52,7 +52,18 @@ $attachments = get_posts( array(
 		<ul class="guide-tree">
 			<?php echo $children; ?>
 
-			<?php dynamic_sidebar( 'guide-sidebar-below-toc' ); ?>
+			<?php 
+
+				// if a sidebar has been chosen in the page editor, try to display it
+				$custom_sidebar = largo_get_custom_sidebar();
+				if( $custom_sidebar !== 'none' && is_active_sidebar( $custom_sidebar ) ) {
+					dynamic_sidebar( $custom_sidebar );	
+				// else, fall back to default guide sidebar
+				} else {	
+					dynamic_sidebar( 'guide-sidebar-below-toc' ); 
+				}
+
+			?>
 		</ul>
 
 		<?php


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

For learn.inn.org:
- Adds in functionality to allow users to select a custom sidebar from the page editor to display on guide pages. Falls back to default guide sidebar is a custom one has not been selected or is empty.

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #155

## Testing/Questions

Features that this PR affects:

- learn.inn.org guide sidebars

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. View a guide page without selecting a sidebar and make sure the default one appears
2. View a guide page after selecting a custom sidebar for it and make sure it appears
3. View a guide page after selecting an **empty** custom sidebar for it and make sure the default sidebar appears